### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/os-sanity.yml
+++ b/.github/workflows/os-sanity.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: os-sanity-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/fwerkor/capos/security/code-scanning/1](https://github.com/fwerkor/capos/security/code-scanning/1)

To fix the problem, explicitly set GitHub Actions `permissions` so that the `GITHUB_TOKEN` has the least privileges needed. For this workflow, the steps only check out the repository and run local tools; they do not interact with issues, PRs, or other write operations. Therefore, setting `contents: read` is an appropriate minimal permission.

The single best fix without changing existing functionality is to add a top-level `permissions` block (applies to all jobs) right after the `on:` section and before `concurrency:` in `.github/workflows/os-sanity.yml`. This will constrain the token for the entire workflow while keeping all existing triggers and job steps intact. No imports or additional methods are required because this is purely a YAML configuration change.

Concretely, in `.github/workflows/os-sanity.yml`, insert:

```yaml
permissions:
  contents: read
```

at the root level (same indentation as `on` and `concurrency`). No other lines need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
