### PR TITLE
website: enrich CapOS content and add multi-page site (Get / Docs / Community / About)

### DIFF
--- a/website/about.html
+++ b/website/about.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About CapOS | 项目定位</title>
+  <meta name="description" content="CapOS 项目定位、愿景与许可证信息。" />
+  <link rel="icon" href="./favicon.ico" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-inner">
+      <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
+      <nav class="menu">
+        <a href="./index.html">首页</a>
+        <a href="./get-capos.html">Get CapOS</a>
+        <a href="./docs.html">文档</a>
+        <a href="./community.html">社区</a>
+        <a class="active" href="./about.html">关于</a>
+      </nav>
+      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <span class="badge">ABOUT CAPOS</span>
+      <h1>让开源 NAS 与边缘系统拥有 <span class="gradient">更低门槛的生产力</span></h1>
+      <p class="lead">CapOS 由 FWERKOR Team 维护，目标是把“轻量系统 + 强生态 + 易用管理”组合成一个完整产品体验。它不是简单的页面美化，而是尝试把专业运维能力带给更广泛人群。</p>
+    </section>
+
+    <section class="section">
+      <h2>项目定位</h2>
+      <div class="grid grid-2">
+        <article class="card">
+          <h3>对个人用户</h3>
+          <p>你可以快速搭建个人 NAS、家庭自动化服务和媒体中心，用较低硬件成本获得稳定系统能力。</p>
+        </article>
+        <article class="card">
+          <h3>对专业用户</h3>
+          <p>你可以保留 CLI、脚本和网络能力，构建更可控的边缘节点体系，并持续扩展服务矩阵。</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>理念与原则</h2>
+      <div class="grid grid-3">
+        <article class="card"><h3>Open First</h3><p>坚持开源开发模式，鼓励社区透明协作与长期演进。</p></article>
+        <article class="card"><h3>Practical First</h3><p>强调“能部署、能维护、能扩展”，避免只停留在概念层面。</p></article>
+        <article class="card"><h3>User First</h3><p>同时重视新手与专家体验：WebDesktop 与 CLI 双路径并行。</p></article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="card">
+        <h3>License</h3>
+        <p>CapOS 基于 GPL-2.0 开源协议发布。欢迎企业与个人在遵守协议的前提下进行研究、部署与二次开发。</p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>FWERKOR Team · Maintained with community</span>
+      <a href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">github.com/fwerkor/capos</a>
+    </div>
+  </footer>
+  <button id="top" aria-label="Back to top">↑</button>
+  <script src="./script.js"></script>
+</body>
+</html>

--- a/website/about.html
+++ b/website/about.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>About CapOS | 项目定位</title>
-  <meta name="description" content="CapOS 项目定位、愿景与许可证信息。" />
+  <title>About CapOS | Mission and Direction</title>
+  <meta name="description" content="Learn what CapOS is, why it exists, and how the project is maintained." />
   <link rel="icon" href="./favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -16,22 +16,22 @@
     <div class="container topbar-inner">
       <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
       <nav class="menu">
-        <a href="./index.html">首页</a>
+        <a href="./index.html">Home</a>
         <a href="./get-capos.html">Get CapOS</a>
-        <a href="./docs.html">文档</a>
-        <a href="./community.html">社区</a>
-        <a class="active" href="./about.html">关于</a>
+        <a href="./docs.html">Docs</a>
+        <a href="./community.html">Community</a>
+        <a class="active" href="./about.html">About</a>
       </nav>
-      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">Menu ☰</button>
       <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       <div id="mobileNav" class="mobile-nav" hidden>
         <nav class="mobile-menu">
-        <a href="./index.html">首页</a>
-        <a href="./get-capos.html">Get CapOS</a>
-        <a href="./docs.html">文档</a>
-        <a href="./community.html">社区</a>
-        <a class="active" href="./about.html">关于</a>
-      </nav>
+          <a href="./index.html">Home</a>
+          <a href="./get-capos.html">Get CapOS</a>
+          <a href="./docs.html">Docs</a>
+          <a href="./community.html">Community</a>
+          <a class="active" href="./about.html">About</a>
+        </nav>
         <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       </div>
     </div>
@@ -40,37 +40,31 @@
   <main class="container">
     <section class="hero">
       <span class="badge">ABOUT CAPOS</span>
-      <h1>让开源 NAS 与边缘系统拥有 <span class="gradient">更低门槛的生产力</span></h1>
-      <p class="lead">CapOS 由 FWERKOR Team 维护，目标是把“轻量系统 + 强生态 + 易用管理”组合成一个完整产品体验。它不是简单的页面美化，而是尝试把专业运维能力带给更广泛人群。</p>
+      <h1>An open platform for <span class="gradient">NAS and edge computing</span></h1>
+      <p class="lead">CapOS is maintained by the FWERKOR Team as an open-source operating system focused on practical server workflows, extensible architecture, and approachable system management.</p>
     </section>
 
     <section class="section">
-      <h2>项目定位</h2>
+      <h2>Project goals</h2>
       <div class="grid grid-2">
-        <article class="card">
-          <h3>对个人用户</h3>
-          <p>你可以快速搭建个人 NAS、家庭自动化服务和媒体中心，用较低硬件成本获得稳定系统能力。</p>
-        </article>
-        <article class="card">
-          <h3>对专业用户</h3>
-          <p>你可以保留 CLI、脚本和网络能力，构建更可控的边缘节点体系，并持续扩展服务矩阵。</p>
-        </article>
+        <article class="card"><h3>For makers and home labs</h3><p>Provide an easy path to deploy storage, media, automation, and self-hosted services on affordable hardware.</p></article>
+        <article class="card"><h3>For advanced users and teams</h3><p>Preserve low-level control, scriptability, and modular expansion for professional and semi-professional environments.</p></article>
       </div>
     </section>
 
     <section class="section">
-      <h2>理念与原则</h2>
+      <h2>Core principles</h2>
       <div class="grid grid-3">
-        <article class="card"><h3>Open First</h3><p>坚持开源开发模式，鼓励社区透明协作与长期演进。</p></article>
-        <article class="card"><h3>Practical First</h3><p>强调“能部署、能维护、能扩展”，避免只停留在概念层面。</p></article>
-        <article class="card"><h3>User First</h3><p>同时重视新手与专家体验：WebDesktop 与 CLI 双路径并行。</p></article>
+        <article class="card"><h3>Open First</h3><p>Transparent development and community collaboration are fundamental to the project.</p></article>
+        <article class="card"><h3>Practical First</h3><p>Design decisions prioritize reliability, maintainability, and real deployment value.</p></article>
+        <article class="card"><h3>User First</h3><p>Balance a smooth WebDesktop experience with strong CLI workflows for advanced operation.</p></article>
       </div>
     </section>
 
     <section class="section">
       <div class="card">
         <h3>License</h3>
-        <p>CapOS 基于 GPL-2.0 开源协议发布。欢迎企业与个人在遵守协议的前提下进行研究、部署与二次开发。</p>
+        <p>CapOS is released under GPL-2.0. Contributions and derivative work are welcome under license terms.</p>
       </div>
     </section>
   </main>

--- a/website/about.html
+++ b/website/about.html
@@ -22,7 +22,18 @@
         <a href="./community.html">社区</a>
         <a class="active" href="./about.html">关于</a>
       </nav>
-      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <div id="mobileNav" class="mobile-nav" hidden>
+        <nav class="mobile-menu">
+        <a href="./index.html">首页</a>
+        <a href="./get-capos.html">Get CapOS</a>
+        <a href="./docs.html">文档</a>
+        <a href="./community.html">社区</a>
+        <a class="active" href="./about.html">关于</a>
+      </nav>
+        <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      </div>
     </div>
   </header>
 

--- a/website/community.html
+++ b/website/community.html
@@ -22,7 +22,18 @@
         <a class="active" href="./community.html">社区</a>
         <a href="./about.html">关于</a>
       </nav>
-      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <div id="mobileNav" class="mobile-nav" hidden>
+        <nav class="mobile-menu">
+        <a href="./index.html">首页</a>
+        <a href="./get-capos.html">Get CapOS</a>
+        <a href="./docs.html">文档</a>
+        <a class="active" href="./community.html">社区</a>
+        <a href="./about.html">关于</a>
+      </nav>
+        <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      </div>
     </div>
   </header>
 

--- a/website/community.html
+++ b/website/community.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CapOS Community | 社区与贡献</title>
+  <meta name="description" content="CapOS 社区支持、反馈与贡献入口。" />
+  <link rel="icon" href="./favicon.ico" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-inner">
+      <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
+      <nav class="menu">
+        <a href="./index.html">首页</a>
+        <a href="./get-capos.html">Get CapOS</a>
+        <a href="./docs.html">文档</a>
+        <a class="active" href="./community.html">社区</a>
+        <a href="./about.html">关于</a>
+      </nav>
+      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <span class="badge">COMMUNITY</span>
+      <h1>把 CapOS 做成更好的 <span class="gradient">开源 NAS 系统</span></h1>
+      <p class="lead">CapOS 欢迎任何形式的贡献：问题反馈、功能建议、代码优化、文档改进、应用生态建设。只要你愿意参与，就能让项目更快进化。</p>
+    </section>
+
+    <section class="section">
+      <h2>参与方式</h2>
+      <div class="grid grid-3">
+        <article class="card"><h3>Issues</h3><p>提交 bug、兼容性问题和需求建议，帮助维护者快速定位优先级。</p><p><a href="https://github.com/fwerkor/capos/issues" target="_blank" rel="noreferrer">打开 Issues</a></p></article>
+        <article class="card"><h3>Discussions</h3><p>发起方案讨论、部署经验交流和新特性 brainstorm，沉淀社区共识。</p><p><a href="https://github.com/fwerkor/capos/discussions" target="_blank" rel="noreferrer">进入 Discussions</a></p></article>
+        <article class="card"><h3>Pull Requests</h3><p>提交代码与文档改进，建议附带可复现步骤和测试结果，便于评审合并。</p><p><a href="https://github.com/fwerkor/capos/pulls" target="_blank" rel="noreferrer">查看 PR</a></p></article>
+      </div>
+    </section>
+
+    <section class="section split">
+      <div class="card">
+        <h3>我们最期待的贡献</h3>
+        <ul>
+          <li>不同硬件架构的镜像测试与适配反馈。</li>
+          <li>WebDesktop 交互优化与可用性改进。</li>
+          <li>应用模板、部署脚本和最佳实践文档。</li>
+          <li>安全策略审查与性能压测数据。</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>协作建议</h3>
+        <p>建议在提交 PR 前先开 Issue 讨论方向，减少重复开发；同时保持提交颗粒度清晰，便于 review 与回滚。</p>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Community-driven, open to everyone.</span>
+      <a href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">Join on GitHub</a>
+    </div>
+  </footer>
+  <button id="top" aria-label="Back to top">↑</button>
+  <script src="./script.js"></script>
+</body>
+</html>

--- a/website/community.html
+++ b/website/community.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CapOS Community | 社区与贡献</title>
-  <meta name="description" content="CapOS 社区支持、反馈与贡献入口。" />
+  <title>CapOS Community | Contribute and Connect</title>
+  <meta name="description" content="Join the CapOS community through issues, discussions, and pull requests." />
   <link rel="icon" href="./favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -16,22 +16,22 @@
     <div class="container topbar-inner">
       <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
       <nav class="menu">
-        <a href="./index.html">首页</a>
+        <a href="./index.html">Home</a>
         <a href="./get-capos.html">Get CapOS</a>
-        <a href="./docs.html">文档</a>
-        <a class="active" href="./community.html">社区</a>
-        <a href="./about.html">关于</a>
+        <a href="./docs.html">Docs</a>
+        <a class="active" href="./community.html">Community</a>
+        <a href="./about.html">About</a>
       </nav>
-      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">Menu ☰</button>
       <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       <div id="mobileNav" class="mobile-nav" hidden>
         <nav class="mobile-menu">
-        <a href="./index.html">首页</a>
-        <a href="./get-capos.html">Get CapOS</a>
-        <a href="./docs.html">文档</a>
-        <a class="active" href="./community.html">社区</a>
-        <a href="./about.html">关于</a>
-      </nav>
+          <a href="./index.html">Home</a>
+          <a href="./get-capos.html">Get CapOS</a>
+          <a href="./docs.html">Docs</a>
+          <a class="active" href="./community.html">Community</a>
+          <a href="./about.html">About</a>
+        </nav>
         <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       </div>
     </div>
@@ -40,39 +40,39 @@
   <main class="container">
     <section class="hero">
       <span class="badge">COMMUNITY</span>
-      <h1>把 CapOS 做成更好的 <span class="gradient">开源 NAS 系统</span></h1>
-      <p class="lead">CapOS 欢迎任何形式的贡献：问题反馈、功能建议、代码优化、文档改进、应用生态建设。只要你愿意参与，就能让项目更快进化。</p>
+      <h1>Help shape the future of <span class="gradient">CapOS</span></h1>
+      <p class="lead">CapOS is developed in the open. Whether you report bugs, improve docs, test builds, or submit code, your contribution directly improves the platform for everyone.</p>
     </section>
 
     <section class="section">
-      <h2>参与方式</h2>
+      <h2>Where to contribute</h2>
       <div class="grid grid-3">
-        <article class="card"><h3>Issues</h3><p>提交 bug、兼容性问题和需求建议，帮助维护者快速定位优先级。</p><p><a href="https://github.com/fwerkor/capos/issues" target="_blank" rel="noreferrer">打开 Issues</a></p></article>
-        <article class="card"><h3>Discussions</h3><p>发起方案讨论、部署经验交流和新特性 brainstorm，沉淀社区共识。</p><p><a href="https://github.com/fwerkor/capos/discussions" target="_blank" rel="noreferrer">进入 Discussions</a></p></article>
-        <article class="card"><h3>Pull Requests</h3><p>提交代码与文档改进，建议附带可复现步骤和测试结果，便于评审合并。</p><p><a href="https://github.com/fwerkor/capos/pulls" target="_blank" rel="noreferrer">查看 PR</a></p></article>
+        <article class="card"><h3>Issues</h3><p>Report bugs, request features, and share compatibility findings.</p><p><a href="https://github.com/fwerkor/capos/issues" target="_blank" rel="noreferrer">Open Issues</a></p></article>
+        <article class="card"><h3>Discussions</h3><p>Share ideas, deployment experiences, and architecture proposals.</p><p><a href="https://github.com/fwerkor/capos/discussions" target="_blank" rel="noreferrer">Join Discussions</a></p></article>
+        <article class="card"><h3>Pull Requests</h3><p>Submit improvements to code, docs, and workflows.</p><p><a href="https://github.com/fwerkor/capos/pulls" target="_blank" rel="noreferrer">Browse PRs</a></p></article>
       </div>
     </section>
 
     <section class="section split">
       <div class="card">
-        <h3>我们最期待的贡献</h3>
+        <h3>High-impact contribution areas</h3>
         <ul>
-          <li>不同硬件架构的镜像测试与适配反馈。</li>
-          <li>WebDesktop 交互优化与可用性改进。</li>
-          <li>应用模板、部署脚本和最佳实践文档。</li>
-          <li>安全策略审查与性能压测数据。</li>
+          <li>Hardware compatibility and boot validation</li>
+          <li>WebDesktop UX and management workflows</li>
+          <li>Documentation quality and onboarding paths</li>
+          <li>Security hardening and performance tuning</li>
         </ul>
       </div>
       <div class="card">
-        <h3>协作建议</h3>
-        <p>建议在提交 PR 前先开 Issue 讨论方向，减少重复开发；同时保持提交颗粒度清晰，便于 review 与回滚。</p>
+        <h3>Collaboration tip</h3>
+        <p>Open a discussion or issue before major implementation work so direction and scope are clear before coding begins.</p>
       </div>
     </section>
   </main>
 
   <footer>
     <div class="container footer-inner">
-      <span>Community-driven, open to everyone.</span>
+      <span>Community-driven and open to everyone.</span>
       <a href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">Join on GitHub</a>
     </div>
   </footer>

--- a/website/docs.html
+++ b/website/docs.html
@@ -22,7 +22,18 @@
         <a href="./community.html">社区</a>
         <a href="./about.html">关于</a>
       </nav>
-      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <div id="mobileNav" class="mobile-nav" hidden>
+        <nav class="mobile-menu">
+        <a href="./index.html">首页</a>
+        <a href="./get-capos.html">Get CapOS</a>
+        <a class="active" href="./docs.html">文档</a>
+        <a href="./community.html">社区</a>
+        <a href="./about.html">关于</a>
+      </nav>
+        <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      </div>
     </div>
   </header>
 

--- a/website/docs.html
+++ b/website/docs.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CapOS Docs | 构建与开发</title>
+  <meta name="description" content="CapOS 构建、开发与运维文档索引。" />
+  <link rel="icon" href="./favicon.ico" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-inner">
+      <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
+      <nav class="menu">
+        <a href="./index.html">首页</a>
+        <a href="./get-capos.html">Get CapOS</a>
+        <a class="active" href="./docs.html">文档</a>
+        <a href="./community.html">社区</a>
+        <a href="./about.html">关于</a>
+      </nav>
+      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <span class="badge">DOCUMENTATION</span>
+      <h1>从编译到部署，<span class="gradient">一条线打通</span></h1>
+      <p class="lead">CapOS 鼓励开发者和高级用户自行构建镜像，并在统一规范下扩展应用。以下内容基于项目 README 提炼，适用于学习、实验与工程化落地。</p>
+    </section>
+
+    <section class="section">
+      <h2>构建 CapOS（概要）</h2>
+      <div class="grid grid-2">
+        <article class="card">
+          <h3>环境要求</h3>
+          <p>推荐 GNU/Linux、BSD 或 macOS（需要区分大小写文件系统）。避免使用 root 用户执行构建流程。</p>
+        </article>
+        <article class="card">
+          <h3>依赖工具</h3>
+          <p>需要 binutils、gcc、make、python3、subversion、rsync 等标准编译工具链。</p>
+        </article>
+      </div>
+      <div class="panel" style="margin-top:14px;">
+        <div class="term-head"><span></span><span></span><span></span><code>build workflow</code></div>
+<pre>bash ./scripts/auto_install_dependencies.sh
+make menuconfig
+make -j$(nproc)</pre>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>能力模型</h2>
+      <div class="grid grid-3">
+        <article class="card"><h3>WebDesktop</h3><p>通过浏览器图形化操作系统，降低学习门槛，帮助非 Linux 专业用户也能稳定管理服务。</p></article>
+        <article class="card"><h3>CLI 友好</h3><p>保留标准 Linux 命令体验，支持自动化脚本与批量运维，兼顾高阶用户习惯。</p></article>
+        <article class="card"><h3>应用扩展</h3><p>可结合社区 package 与 CapOS 应用能力持续扩展，构建面向家庭和专业场景的服务组合。</p></article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="cta">
+        <h3>更多参考入口</h3>
+        <div class="row">
+          <a class="btn btn-primary" href="https://blog.fwerkor.com/category/capos" target="_blank" rel="noreferrer">FWERKOR Blog</a>
+          <a class="btn btn-ghost" href="https://github.com/fwerkor/capp-helloworld" target="_blank" rel="noreferrer">CAPP HelloWorld</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Docs · Build · Develop · Operate</span>
+      <a href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">Source Code</a>
+    </div>
+  </footer>
+  <button id="top" aria-label="Back to top">↑</button>
+  <script src="./script.js"></script>
+</body>
+</html>

--- a/website/docs.html
+++ b/website/docs.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CapOS Docs | 构建与开发</title>
-  <meta name="description" content="CapOS 构建、开发与运维文档索引。" />
+  <title>CapOS Docs | Build, Deploy, Develop</title>
+  <meta name="description" content="Documentation overview for building, deploying, and developing on CapOS." />
   <link rel="icon" href="./favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -16,22 +16,22 @@
     <div class="container topbar-inner">
       <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
       <nav class="menu">
-        <a href="./index.html">首页</a>
+        <a href="./index.html">Home</a>
         <a href="./get-capos.html">Get CapOS</a>
-        <a class="active" href="./docs.html">文档</a>
-        <a href="./community.html">社区</a>
-        <a href="./about.html">关于</a>
+        <a class="active" href="./docs.html">Docs</a>
+        <a href="./community.html">Community</a>
+        <a href="./about.html">About</a>
       </nav>
-      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">Menu ☰</button>
       <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       <div id="mobileNav" class="mobile-nav" hidden>
         <nav class="mobile-menu">
-        <a href="./index.html">首页</a>
-        <a href="./get-capos.html">Get CapOS</a>
-        <a class="active" href="./docs.html">文档</a>
-        <a href="./community.html">社区</a>
-        <a href="./about.html">关于</a>
-      </nav>
+          <a href="./index.html">Home</a>
+          <a href="./get-capos.html">Get CapOS</a>
+          <a class="active" href="./docs.html">Docs</a>
+          <a href="./community.html">Community</a>
+          <a href="./about.html">About</a>
+        </nav>
         <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       </div>
     </div>
@@ -40,21 +40,15 @@
   <main class="container">
     <section class="hero">
       <span class="badge">DOCUMENTATION</span>
-      <h1>从编译到部署，<span class="gradient">一条线打通</span></h1>
-      <p class="lead">CapOS 鼓励开发者和高级用户自行构建镜像，并在统一规范下扩展应用。以下内容基于项目 README 提炼，适用于学习、实验与工程化落地。</p>
+      <h1>Build, deploy, and customize <span class="gradient">CapOS</span></h1>
+      <p class="lead">CapOS supports both quick deployment and full source-based workflows. Use this page as an entry point to system setup, firmware builds, and app development resources.</p>
     </section>
 
     <section class="section">
-      <h2>构建 CapOS（概要）</h2>
+      <h2>Build from source</h2>
       <div class="grid grid-2">
-        <article class="card">
-          <h3>环境要求</h3>
-          <p>推荐 GNU/Linux、BSD 或 macOS（需要区分大小写文件系统）。避免使用 root 用户执行构建流程。</p>
-        </article>
-        <article class="card">
-          <h3>依赖工具</h3>
-          <p>需要 binutils、gcc、make、python3、subversion、rsync 等标准编译工具链。</p>
-        </article>
+        <article class="card"><h3>Recommended host systems</h3><p>GNU/Linux, BSD, or macOS with a case-sensitive filesystem. Use a non-root user for all build steps.</p></article>
+        <article class="card"><h3>Core toolchain requirements</h3><p>Use standard build tools including gcc, make, python3, rsync, subversion, and related utilities.</p></article>
       </div>
       <div class="panel" style="margin-top:14px;">
         <div class="term-head"><span></span><span></span><span></span><code>build workflow</code></div>
@@ -65,28 +59,18 @@ make -j$(nproc)</pre>
     </section>
 
     <section class="section">
-      <h2>能力模型</h2>
+      <h2>Platform capabilities</h2>
       <div class="grid grid-3">
-        <article class="card"><h3>WebDesktop</h3><p>通过浏览器图形化操作系统，降低学习门槛，帮助非 Linux 专业用户也能稳定管理服务。</p></article>
-        <article class="card"><h3>CLI 友好</h3><p>保留标准 Linux 命令体验，支持自动化脚本与批量运维，兼顾高阶用户习惯。</p></article>
-        <article class="card"><h3>应用扩展</h3><p>可结合社区 package 与 CapOS 应用能力持续扩展，构建面向家庭和专业场景的服务组合。</p></article>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="cta">
-        <h3>更多参考入口</h3>
-        <div class="row">
-          <a class="btn btn-primary" href="https://blog.fwerkor.com/category/capos" target="_blank" rel="noreferrer">FWERKOR Blog</a>
-          <a class="btn btn-ghost" href="https://github.com/fwerkor/capp-helloworld" target="_blank" rel="noreferrer">CAPP HelloWorld</a>
-        </div>
+        <article class="card"><h3>WebDesktop Operations</h3><p>Operate core server workflows through a browser-based desktop interface that lowers the entry barrier.</p></article>
+        <article class="card"><h3>CLI Automation</h3><p>Use shell scripts and standard Linux commands for reproducible operations and advanced administration.</p></article>
+        <article class="card"><h3>App Extensibility</h3><p>Expand your system with packages and custom application stacks to match home and professional scenarios.</p></article>
       </div>
     </section>
   </main>
 
   <footer>
     <div class="container footer-inner">
-      <span>Docs · Build · Develop · Operate</span>
+      <span>Docs · Build · Operate · Extend</span>
       <a href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">Source Code</a>
     </div>
   </footer>

--- a/website/get-capos.html
+++ b/website/get-capos.html
@@ -22,7 +22,18 @@
         <a href="./community.html">社区</a>
         <a href="./about.html">关于</a>
       </nav>
-      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <div id="mobileNav" class="mobile-nav" hidden>
+        <nav class="mobile-menu">
+        <a href="./index.html">首页</a>
+        <a class="active" href="./get-capos.html">Get CapOS</a>
+        <a href="./docs.html">文档</a>
+        <a href="./community.html">社区</a>
+        <a href="./about.html">关于</a>
+      </nav>
+        <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      </div>
     </div>
   </header>
 

--- a/website/get-capos.html
+++ b/website/get-capos.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Get CapOS | 下载与部署</title>
+  <meta name="description" content="CapOS 下载、安装与快速部署指南。" />
+  <link rel="icon" href="./favicon.ico" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-inner">
+      <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
+      <nav class="menu">
+        <a href="./index.html">首页</a>
+        <a class="active" href="./get-capos.html">Get CapOS</a>
+        <a href="./docs.html">文档</a>
+        <a href="./community.html">社区</a>
+        <a href="./about.html">关于</a>
+      </nav>
+      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="hero">
+      <span class="badge">GET CAPOS</span>
+      <h1>下载、刷写、启动你的 <span class="gradient">CapOS 节点</span></h1>
+      <p class="lead">你可以直接使用官方编译版本，也可以根据硬件架构自行构建镜像。建议先在测试环境验证，再迁移到正式 NAS 或边缘节点。</p>
+      <div class="row">
+        <a class="btn btn-primary" href="https://github.com/fwerkor/capos/releases" target="_blank" rel="noreferrer">GitHub Releases</a>
+        <a class="btn btn-ghost" href="https://repo.fwerkor.com/capos" target="_blank" rel="noreferrer">FWERKOR Repo</a>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>部署方式</h2>
+      <div class="grid grid-3">
+        <article class="card"><h3>路由器 / ARM 设备</h3><p>适用于低功耗 NAS、网关与家庭边缘服务。充分利用轻量设计与高可用网络能力。</p></article>
+        <article class="card"><h3>x86 小主机 / 旧电脑</h3><p>可构建个人数据中心，运行文件管理、媒体服务与自动化任务，兼顾性能与成本。</p></article>
+        <article class="card"><h3>虚拟机环境</h3><p>推荐用于学习、测试与 CI 验证，便于快照回滚和多版本对比。</p></article>
+      </div>
+    </section>
+
+    <section class="section split">
+      <div class="card">
+        <h3>默认访问端口（README 同步）</h3>
+        <div class="table-like">
+          <div><strong>Web Panel</strong><span>http: 2000/tcp · https: 2020/tcp</span></div>
+          <div><strong>SSH</strong><span>22/tcp（设置 root 密码后）</span></div>
+          <div><strong>Telnet</strong><span>23/tcp（仅初始阶段）</span></div>
+          <div><strong>网络默认</strong><span>DHCP + DHCPv6</span></div>
+        </div>
+      </div>
+      <div class="card">
+        <h3>快速验证</h3>
+<pre># 首次登录后建议立即修改凭据
+passwd
+
+# 查看服务状态
+service status
+
+# 按需安装扩展包（示意）
+opkg update
+opkg list | head -n 20</pre>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="cta">
+        <h3>下一步：阅读构建与开发文档</h3>
+        <div class="row">
+          <a class="btn btn-primary" href="./docs.html">前往文档页</a>
+          <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">项目仓库</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-inner">
+      <span>Get CapOS · Deploy anywhere</span>
+      <a href="https://github.com/fwerkor/capos/releases" target="_blank" rel="noreferrer">Release Channel</a>
+    </div>
+  </footer>
+  <button id="top" aria-label="Back to top">↑</button>
+  <script src="./script.js"></script>
+</body>
+</html>

--- a/website/get-capos.html
+++ b/website/get-capos.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Get CapOS | 下载与部署</title>
-  <meta name="description" content="CapOS 下载、安装与快速部署指南。" />
+  <title>Get CapOS | Download & Install</title>
+  <meta name="description" content="Download CapOS builds and deploy them on your hardware or virtual environments." />
   <link rel="icon" href="./favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -16,22 +16,22 @@
     <div class="container topbar-inner">
       <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
       <nav class="menu">
-        <a href="./index.html">首页</a>
+        <a href="./index.html">Home</a>
         <a class="active" href="./get-capos.html">Get CapOS</a>
-        <a href="./docs.html">文档</a>
-        <a href="./community.html">社区</a>
-        <a href="./about.html">关于</a>
+        <a href="./docs.html">Docs</a>
+        <a href="./community.html">Community</a>
+        <a href="./about.html">About</a>
       </nav>
-      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">Menu ☰</button>
       <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       <div id="mobileNav" class="mobile-nav" hidden>
         <nav class="mobile-menu">
-        <a href="./index.html">首页</a>
-        <a class="active" href="./get-capos.html">Get CapOS</a>
-        <a href="./docs.html">文档</a>
-        <a href="./community.html">社区</a>
-        <a href="./about.html">关于</a>
-      </nav>
+          <a href="./index.html">Home</a>
+          <a class="active" href="./get-capos.html">Get CapOS</a>
+          <a href="./docs.html">Docs</a>
+          <a href="./community.html">Community</a>
+          <a href="./about.html">About</a>
+        </nav>
         <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       </div>
     </div>
@@ -40,61 +40,51 @@
   <main class="container">
     <section class="hero">
       <span class="badge">GET CAPOS</span>
-      <h1>下载、刷写、启动你的 <span class="gradient">CapOS 节点</span></h1>
-      <p class="lead">你可以直接使用官方编译版本，也可以根据硬件架构自行构建镜像。建议先在测试环境验证，再迁移到正式 NAS 或边缘节点。</p>
+      <h1>Download and boot your <span class="gradient">CapOS node</span></h1>
+      <p class="lead">Use official builds for a fast start, or compile your own firmware for architecture-specific optimization and advanced customization.</p>
       <div class="row">
         <a class="btn btn-primary" href="https://github.com/fwerkor/capos/releases" target="_blank" rel="noreferrer">GitHub Releases</a>
-        <a class="btn btn-ghost" href="https://repo.fwerkor.com/capos" target="_blank" rel="noreferrer">FWERKOR Repo</a>
+        <a class="btn btn-ghost" href="https://repo.fwerkor.com/capos" target="_blank" rel="noreferrer">FWERKOR Repository</a>
       </div>
     </section>
 
     <section class="section">
-      <h2>部署方式</h2>
+      <h2>Deployment targets</h2>
       <div class="grid grid-3">
-        <article class="card"><h3>路由器 / ARM 设备</h3><p>适用于低功耗 NAS、网关与家庭边缘服务。充分利用轻量设计与高可用网络能力。</p></article>
-        <article class="card"><h3>x86 小主机 / 旧电脑</h3><p>可构建个人数据中心，运行文件管理、媒体服务与自动化任务，兼顾性能与成本。</p></article>
-        <article class="card"><h3>虚拟机环境</h3><p>推荐用于学习、测试与 CI 验证，便于快照回滚和多版本对比。</p></article>
+        <article class="card"><h3>ARM devices</h3><p>Great for low-power NAS nodes, network appliances, and always-on home edge services.</p></article>
+        <article class="card"><h3>x86 mini PCs</h3><p>Perfect for file servers, media platforms, and automation workloads with stronger compute needs.</p></article>
+        <article class="card"><h3>Virtual machines</h3><p>Best for evaluation, CI testing, and staging before deployment to physical hardware.</p></article>
       </div>
     </section>
 
     <section class="section split">
       <div class="card">
-        <h3>默认访问端口（README 同步）</h3>
+        <h3>Default access points</h3>
         <div class="table-like">
-          <div><strong>Web Panel</strong><span>http: 2000/tcp · https: 2020/tcp</span></div>
-          <div><strong>SSH</strong><span>22/tcp（设置 root 密码后）</span></div>
-          <div><strong>Telnet</strong><span>23/tcp（仅初始阶段）</span></div>
-          <div><strong>网络默认</strong><span>DHCP + DHCPv6</span></div>
+          <div><strong>Web Panel</strong><span>HTTP 2000/tcp · HTTPS 2020/tcp</span></div>
+          <div><strong>SSH</strong><span>22/tcp (after root password is set)</span></div>
+          <div><strong>Telnet</strong><span>23/tcp (initial bootstrap stage)</span></div>
+          <div><strong>Network defaults</strong><span>DHCP + DHCPv6</span></div>
         </div>
       </div>
       <div class="card">
-        <h3>快速验证</h3>
-<pre># 首次登录后建议立即修改凭据
+        <h3>First-run checklist</h3>
+<pre># Secure credentials
 passwd
 
-# 查看服务状态
+# Verify system services
 service status
 
-# 按需安装扩展包（示意）
+# Inspect package availability
 opkg update
 opkg list | head -n 20</pre>
-      </div>
-    </section>
-
-    <section class="section">
-      <div class="cta">
-        <h3>下一步：阅读构建与开发文档</h3>
-        <div class="row">
-          <a class="btn btn-primary" href="./docs.html">前往文档页</a>
-          <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">项目仓库</a>
-        </div>
       </div>
     </section>
   </main>
 
   <footer>
     <div class="container footer-inner">
-      <span>Get CapOS · Deploy anywhere</span>
+      <span>Get CapOS · Download, deploy, scale</span>
       <a href="https://github.com/fwerkor/capos/releases" target="_blank" rel="noreferrer">Release Channel</a>
     </div>
   </footer>

--- a/website/index.html
+++ b/website/index.html
@@ -1,166 +1,123 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="zh-CN">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CapOS - FWERKOR 科研项目</title>
-    <!-- 引入Tailwind CSS -->
-    <script src="https://cdn.tailwindcss.com"></script>
-    <!-- 引入Inter字体 -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-    <!-- 引入Font Awesome图标 -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    
-    <!-- Tailwind配置（与首页保持一致的配色体系） -->
-    <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    colors: {
-                        primary: '#0F172A', // 深蓝主色
-                        accent: '#06B6D4', // 青蓝色强调色
-                        secondary: '#1E293B', // 次深色
-                        code: '#111827',
-                    },
-                    fontFamily: {
-                        inter: ['Inter', 'sans-serif'],
-                    },
-                }
-            }
-        }
-    </script>
-    
-    <!-- 自定义样式 -->
-    <style type="text/tailwindcss">
-        @layer utilities {
-            .content-auto {
-                content-visibility: auto;
-            }
-            .text-shadow {
-                text-shadow: 0 2px 15px rgba(6, 182, 212, 0.3);
-            }
-            .bg-noise {
-                background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)' opacity='0.05'/%3E%3C/svg%3E");
-            }
-            .bg-gradient-tech {
-                background: linear-gradient(135deg, #0F172A 0%, #1E293B 100%);
-            }
-            .hover-lift {
-                @apply transition-all duration-300 hover:translate-y-[-4px] hover:shadow-lg hover:shadow-accent/20;
-            }
-        }
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CapOS | 开源 NAS 与轻量服务器操作系统</title>
+  <meta name="description" content="CapOS 是基于 OpenWrt 的开源 NAS / 轻量服务器操作系统，拥有强生态、高扩展、轻量化与 WebDesktop 管理体验。" />
+  <link rel="icon" href="./favicon.ico" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./styles.css" />
 </head>
+<body>
+  <header class="topbar">
+    <div class="container topbar-inner">
+      <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
+      <nav class="menu">
+        <a class="active" href="./index.html">首页</a>
+        <a href="./get-capos.html">Get CapOS</a>
+        <a href="./docs.html">文档</a>
+        <a href="./community.html">社区</a>
+        <a href="./about.html">关于</a>
+      </nav>
+      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+    </div>
+  </header>
 
-<body class="font-inter bg-primary text-white bg-noise min-h-screen">
-    <!-- 导航栏 -->
-    <nav class="fixed top-0 left-0 w-full z-50 py-4 px-6 md:px-12 bg-primary/90 backdrop-blur-md shadow-lg">
-        <div class="container mx-auto flex justify-between items-center">
-            <!-- 团队Logo + 返回首页 -->
-            <a href="/" class="text-2xl font-bold text-accent flex items-center gap-2">
-                <i class="fa-solid fa-microchip"></i>
-                <span>FWERKOR</span>
-                <span class="text-white text-sm font-normal ml-2">/ CapOS</span>
-            </a>
-            
-            <!-- GitHub链接 -->
-            <a href="https://github.com/fwerkor/capos" target="_blank" class="flex items-center gap-2 text-gray-300 hover:text-accent transition-colors hover-lift">
-                <i class="fa-brands fa-github text-xl"></i>
-                <span class="hidden md:inline">GitHub</span>
-            </a>
-        </div>
-    </nav>
-
-    <!-- 英雄区 -->
-    <section class="h-screen flex items-center justify-center px-6 md:px-12 pt-20">
-        <div class="container mx-auto max-w-5xl">
-            <div class="flex flex-col md:flex-row items-center gap-8 md:gap-12">
-                <!-- 左侧标题区 -->
-                <div class="w-full md:w-1/2">
-                    <span class="inline-block text-accent text-sm font-medium px-3 py-1 rounded-full bg-accent/10 mb-4">
-                        <i class="fa-solid fa-code mr-2"></i>操作系统
-                    </span>
-                    <h1 class="text-[clamp(2.8rem,8vw,5rem)] font-extrabold leading-tight text-shadow mb-6">
-                        Cap<span class="text-accent">OS</span>
-                    </h1>
-                    <p class="text-gray-300 text-lg md:text-xl mb-8">
-                        轻量、稳定、兼容、安全、易用的新一代操作系统
-                    </p>
-                    <!-- GitHub按钮 -->
-                    <a href="https://github.com/fwerkor/capos" target="_blank" class="inline-flex items-center justify-center gap-2 bg-code border border-gray-700 rounded-lg px-6 py-3 hover-lift">
-                        <i class="fa-brands fa-github text-xl"></i>
-                        <span>访问项目仓库</span>
-                    </a>
-                </div>
-                
-                <!-- 右侧代码风格装饰块 -->
-                <div class="w-full md:w-1/2 bg-code border border-gray-700 rounded-xl p-6 shadow-xl shadow-accent/10">
-                    <div class="flex items-center gap-2 mb-4">
-                        <div class="w-3 h-3 rounded-full bg-red-500"></div>
-                        <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
-                        <div class="w-3 h-3 rounded-full bg-green-500"></div>
-                        <span class="text-gray-400 text-sm ml-2">capos/kernel/main.c</span>
-                    </div>
-                    <pre class="text-sm md:text-base text-gray-300 font-mono leading-relaxed overflow-x-auto">
-<span class="text-accent">// CapOS 核心初始化入口</span>
-int capos_kernel_init(void) {
-    <span class="text-purple-400">// 初始化内存管理</span>
-    mem_manager_init();
-    <span class="text-purple-400">// 初始化进程调度</span>
-    scheduler_init();
-    <span class="text-purple-400">// 初始化设备驱动</span>
-    driver_manager_init();
-    
-    <span class="text-green-400">return CAPOS_SUCCESS</span>;
-}</pre>
-                </div>
-            </div>
-        </div>
+  <main class="container">
+    <section class="hero">
+      <span class="badge">OPEN SOURCE · NAS · EDGE SERVER</span>
+      <h1>把 <span class="gradient">OpenWrt 的稳定内核</span> 带到现代 NAS 与家庭实验室体验里</h1>
+      <p class="lead">CapOS 本质是一个开源 NAS / 轻量服务器操作系统：继承 OpenWrt 生态优势，强调轻量与可扩展；同时提供 WebDesktop 管理体验，让非专业用户也能完成服务部署、系统运维与资源管理。</p>
+      <div class="row">
+        <a class="btn btn-primary" href="./get-capos.html">立即开始</a>
+        <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">查看源码</a>
+        <a class="btn btn-ghost" href="./docs.html">阅读文档</a>
+      </div>
+      <div class="panel">
+        <div class="term-head"><span></span><span></span><span></span><code>capos boot / service profile</code></div>
+<pre>[ OK ] init: lightweight core modules loaded
+[ OK ] webdesktop: ready at :2000 / :2020
+[ OK ] package manager: community feeds online
+[ OK ] security baseline: firewall + user isolation
+[ RUN] caposctl app install file-manager media-stack</pre>
+      </div>
     </section>
 
-    <!-- 项目介绍区 -->
-    <section class="py-20 px-6 md:px-12 bg-secondary/30">
-        <div class="container mx-auto max-w-4xl">
-            <h2 class="text-2xl md:text-3xl font-bold mb-8 text-center">
-                <span class="text-accent">#</span> 项目介绍
-            </h2>
-            <div class="bg-code/50 border border-gray-700 rounded-xl p-8 md:p-10 shadow-lg">
-                <p class="text-gray-200 leading-relaxed text-lg">
-                    物联网技术的蓬勃发展推动轻量化运算设施需求激增，而现有NAS系统普遍面临闭源封闭、兼容性受限、应用集成松散、非专业用户操作门槛高等痛点，难以适配多场景使用需求。为填补这一空白，本课题拟研发一个开源轻量化服务器操作系统，并基于开源技术体系构建兼顾易用性、安全性与扩展性的新型系统生态。核心目标是突破现有系统的应用隔离与权限管控局限，实现多用户安全共享与资源精细化管理，让专业用户高效完成扩展配置，非专业用户无需技术积累即可轻松使用各类功能，同时为商业运营场景提供灵活的部署方案，达成“轻量化设备，全场景赋能”的应用效果。核心创新在于采用开源内核与分层架构设计，实现开源兼容性与商业化增值服务的有机平衡，兼顾技术开放性与可持续发展；创新多维度隔离机制，构建用户、应用、资源的全链路隔离体系，保障系统安全与运行稳定；打造一体化应用生态与可视化操作界面，整合全场景功能模块，实现应用一键部署与智能适配，降低操作复杂度；建立跨架构适配体系，兼容多硬件平台，突破现有系统的硬件绑定限制，拓展应用边界。本课题成果可覆盖个人用户、专业玩家与商业运营等多类场景，既能满足私人存储、智能家居管理等个人需求，又能为专业用户提供高效扩展能力，同时助力商业场景实现设备资源的集约化管理。
-                </p>
-            </div>
-        </div>
+    <section class="section">
+      <div class="kicker">WHY CAPOS</div>
+      <h2>围绕“生态、扩展、轻量、易用”打造</h2>
+      <div class="grid grid-3">
+        <article class="card">
+          <h3>生态强大</h3>
+          <p>CapOS 基于 OpenWrt 技术体系，天然具备成熟包生态与多架构兼容基础，既适合老硬件再利用，也利于持续演进。</p>
+        </article>
+        <article class="card">
+          <h3>扩展性强</h3>
+          <p>你可以按需叠加服务与模块，构建个人 NAS、下载中心、家庭自动化中枢，或作为边缘节点运行专业应用。</p>
+        </article>
+        <article class="card">
+          <h3>轻量而实用</h3>
+          <p>延续 OpenWrt 的小体积与低资源占用特性，在路由器、x86 主机、虚拟机等环境都能平稳运行。</p>
+        </article>
+        <article class="card">
+          <h3>WebDesktop 管理</h3>
+          <p>通过浏览器即可完成配置、监控和软件安装；相比纯命令行方案，对新手更友好，对老手更高效。</p>
+        </article>
+        <article class="card">
+          <h3>安全与稳定</h3>
+          <p>遵循稳健系统基线，默认防火墙策略清晰，并持续跟进内核与软件包更新，兼顾长期可维护性。</p>
+        </article>
+        <article class="card">
+          <h3>真正开源</h3>
+          <p>GPL-2.0 许可，欢迎社区通过 Issue、Discussion、PR 参与建设，让 CapOS 持续变得更完整。</p>
+        </article>
+      </div>
     </section>
 
-    <!-- 底部行动区 -->
-    <section class="py-16 px-6 md:px-12">
-        <div class="container mx-auto max-w-3xl text-center">
-            <h3 class="text-2xl font-bold mb-6">探索CapOS的更多可能性</h3>
-            <a href="https://github.com/fwerkor/capos" target="_blank" class="inline-flex items-center justify-center gap-2 bg-accent text-primary font-medium rounded-lg px-8 py-4 text-lg hover-lift">
-                <i class="fa-brands fa-github mr-2"></i>
-                前往GitHub查看源码
-            </a>
+    <section class="section split">
+      <div class="card">
+        <div class="kicker">ROADMAP</div>
+        <h3>开发路线（示例）</h3>
+        <div class="timeline">
+          <div><b>2026 H1</b><p>强化基础镜像构建能力，优化多架构启动和驱动兼容策略。</p></div>
+          <div><b>2026 H2</b><p>完善 WebDesktop 的应用管理与资源可视化，提升新手开箱体验。</p></div>
+          <div><b>2027</b><p>增强插件化与应用交付规范，形成更健康的 CapOS 应用生态。</p></div>
         </div>
+      </div>
+      <div class="card">
+        <div class="kicker">QUICK LINKS</div>
+        <h3>快速访问</h3>
+        <ul>
+          <li><a href="./get-capos.html">下载与安装入口（Get CapOS）</a></li>
+          <li><a href="./docs.html">构建、部署与运维文档</a></li>
+          <li><a href="./community.html">社区支持与贡献方式</a></li>
+          <li><a href="https://github.com/fwerkor/capos/releases" target="_blank" rel="noreferrer">GitHub Releases</a></li>
+        </ul>
+      </div>
     </section>
 
-    <!-- 页脚 -->
-    <footer class="bg-secondary py-10 px-6 md:px-12 border-t border-gray-700">
-        <div class="container mx-auto text-center text-gray-400">
-            <p>© 2026 FWERKOR 烽尔科技有限公司</p>
-            <p class="text-sm mt-2">CapOS - 嵌入式与边缘计算操作系统内核</p>
+    <section class="section">
+      <div class="cta">
+        <h3>准备部署到 www.capos.org？</h3>
+        <p class="desc">该站点为纯静态多页面结构（HTML/CSS/JS），便于低成本托管与长期维护，也方便后续接入文档系统或下载镜像索引。</p>
+        <div class="row">
+          <a class="btn btn-primary" href="./get-capos.html">查看部署入口</a>
+          <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">github.com/fwerkor/capos</a>
         </div>
-    </footer>
+      </div>
+    </section>
+  </main>
 
-    <!-- 平滑滚动脚本 -->
-    <script>
-        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-            anchor.addEventListener('click', function (e) {
-                e.preventDefault();
-                document.querySelector(this.getAttribute('href')).scrollIntoView({
-                    behavior: 'smooth'
-                });
-            });
-        });
-    </script>
+  <footer>
+    <div class="container footer-inner">
+      <span>© 2026 CapOS Community · Open-source NAS & Server OS</span>
+      <a href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">github.com/fwerkor/capos</a>
+    </div>
+  </footer>
+  <button id="top" aria-label="Back to top">↑</button>
+  <script src="./script.js"></script>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -22,7 +22,18 @@
         <a href="./community.html">社区</a>
         <a href="./about.html">关于</a>
       </nav>
-      <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      <div id="mobileNav" class="mobile-nav" hidden>
+        <nav class="mobile-menu">
+        <a class="active" href="./index.html">首页</a>
+        <a href="./get-capos.html">Get CapOS</a>
+        <a href="./docs.html">文档</a>
+        <a href="./community.html">社区</a>
+        <a href="./about.html">关于</a>
+      </nav>
+        <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
+      </div>
     </div>
   </header>
 

--- a/website/index.html
+++ b/website/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CapOS | 开源 NAS 与轻量服务器操作系统</title>
-  <meta name="description" content="CapOS 是基于 OpenWrt 的开源 NAS / 轻量服务器操作系统，拥有强生态、高扩展、轻量化与 WebDesktop 管理体验。" />
+  <title>CapOS | Open-Source NAS & Server OS</title>
+  <meta name="description" content="CapOS is an open-source NAS and lightweight server operating system with a web desktop, rich package ecosystem, and strong extensibility." />
   <link rel="icon" href="./favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -16,22 +16,22 @@
     <div class="container topbar-inner">
       <a class="brand" href="./index.html"><span class="brand-dot"></span>CapOS</a>
       <nav class="menu">
-        <a class="active" href="./index.html">首页</a>
+        <a class="active" href="./index.html">Home</a>
         <a href="./get-capos.html">Get CapOS</a>
-        <a href="./docs.html">文档</a>
-        <a href="./community.html">社区</a>
-        <a href="./about.html">关于</a>
+        <a href="./docs.html">Docs</a>
+        <a href="./community.html">Community</a>
+        <a href="./about.html">About</a>
       </nav>
-      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">菜单 ☰</button>
+      <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobileNav">Menu ☰</button>
       <a class="btn btn-ghost header-github" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       <div id="mobileNav" class="mobile-nav" hidden>
         <nav class="mobile-menu">
-        <a class="active" href="./index.html">首页</a>
-        <a href="./get-capos.html">Get CapOS</a>
-        <a href="./docs.html">文档</a>
-        <a href="./community.html">社区</a>
-        <a href="./about.html">关于</a>
-      </nav>
+          <a class="active" href="./index.html">Home</a>
+          <a href="./get-capos.html">Get CapOS</a>
+          <a href="./docs.html">Docs</a>
+          <a href="./community.html">Community</a>
+          <a href="./about.html">About</a>
+        </nav>
         <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">GitHub ↗</a>
       </div>
     </div>
@@ -40,83 +40,65 @@
   <main class="container">
     <section class="hero">
       <span class="badge">OPEN SOURCE · NAS · EDGE SERVER</span>
-      <h1>把 <span class="gradient">OpenWrt 的稳定内核</span> 带到现代 NAS 与家庭实验室体验里</h1>
-      <p class="lead">CapOS 本质是一个开源 NAS / 轻量服务器操作系统：继承 OpenWrt 生态优势，强调轻量与可扩展；同时提供 WebDesktop 管理体验，让非专业用户也能完成服务部署、系统运维与资源管理。</p>
+      <h1>Build your next home lab on <span class="gradient">CapOS</span></h1>
+      <p class="lead">CapOS is an open-source NAS and server operating system designed for home labs, edge devices, and lightweight infrastructure. It combines a clean WebDesktop experience with a package-rich Linux ecosystem, so both beginners and advanced users can deploy services quickly.</p>
       <div class="row">
-        <a class="btn btn-primary" href="./get-capos.html">立即开始</a>
-        <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">查看源码</a>
-        <a class="btn btn-ghost" href="./docs.html">阅读文档</a>
+        <a class="btn btn-primary" href="./get-capos.html">Get CapOS</a>
+        <a class="btn btn-ghost" href="./docs.html">Read Docs</a>
+        <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">View Source</a>
       </div>
       <div class="panel">
-        <div class="term-head"><span></span><span></span><span></span><code>capos boot / service profile</code></div>
-<pre>[ OK ] init: lightweight core modules loaded
-[ OK ] webdesktop: ready at :2000 / :2020
-[ OK ] package manager: community feeds online
-[ OK ] security baseline: firewall + user isolation
-[ RUN] caposctl app install file-manager media-stack</pre>
+        <div class="term-head"><span></span><span></span><span></span><code>capos startup profile</code></div>
+<pre>[ OK ] init: lightweight core services loaded
+[ OK ] webdesktop: online and ready
+[ OK ] package feeds: synchronized
+[ OK ] network baseline: firewall active
+[ RUN] caposctl app install media-stack backup-tools</pre>
       </div>
     </section>
 
     <section class="section">
       <div class="kicker">WHY CAPOS</div>
-      <h2>围绕“生态、扩展、轻量、易用”打造</h2>
+      <h2>Everything you need for a modern open NAS platform</h2>
       <div class="grid grid-3">
-        <article class="card">
-          <h3>生态强大</h3>
-          <p>CapOS 基于 OpenWrt 技术体系，天然具备成熟包生态与多架构兼容基础，既适合老硬件再利用，也利于持续演进。</p>
-        </article>
-        <article class="card">
-          <h3>扩展性强</h3>
-          <p>你可以按需叠加服务与模块，构建个人 NAS、下载中心、家庭自动化中枢，或作为边缘节点运行专业应用。</p>
-        </article>
-        <article class="card">
-          <h3>轻量而实用</h3>
-          <p>延续 OpenWrt 的小体积与低资源占用特性，在路由器、x86 主机、虚拟机等环境都能平稳运行。</p>
-        </article>
-        <article class="card">
-          <h3>WebDesktop 管理</h3>
-          <p>通过浏览器即可完成配置、监控和软件安装；相比纯命令行方案，对新手更友好，对老手更高效。</p>
-        </article>
-        <article class="card">
-          <h3>安全与稳定</h3>
-          <p>遵循稳健系统基线，默认防火墙策略清晰，并持续跟进内核与软件包更新，兼顾长期可维护性。</p>
-        </article>
-        <article class="card">
-          <h3>真正开源</h3>
-          <p>GPL-2.0 许可，欢迎社区通过 Issue、Discussion、PR 参与建设，让 CapOS 持续变得更完整。</p>
-        </article>
+        <article class="card"><h3>Lightweight by Design</h3><p>Small footprint and efficient resource usage, ideal for routers, mini PCs, virtual machines, and repurposed hardware.</p></article>
+        <article class="card"><h3>Powerful Ecosystem</h3><p>Built on a mature Linux package ecosystem so you can install services fast and keep your stack flexible over time.</p></article>
+        <article class="card"><h3>WebDesktop + CLI</h3><p>Use the visual web interface for day-to-day management and switch to CLI when you need fine-grained control.</p></article>
+        <article class="card"><h3>Extensible Architecture</h3><p>Add apps and services as your needs grow—from file sharing and media servers to automation and edge workloads.</p></article>
+        <article class="card"><h3>Secure Baseline</h3><p>Sensible defaults and stable update practices help keep your home lab and server environment reliable.</p></article>
+        <article class="card"><h3>Community Driven</h3><p>GPL-licensed and open for contributions through issues, discussions, and pull requests on GitHub.</p></article>
       </div>
     </section>
 
     <section class="section split">
       <div class="card">
-        <div class="kicker">ROADMAP</div>
-        <h3>开发路线（示例）</h3>
-        <div class="timeline">
-          <div><b>2026 H1</b><p>强化基础镜像构建能力，优化多架构启动和驱动兼容策略。</p></div>
-          <div><b>2026 H2</b><p>完善 WebDesktop 的应用管理与资源可视化，提升新手开箱体验。</p></div>
-          <div><b>2027</b><p>增强插件化与应用交付规范，形成更健康的 CapOS 应用生态。</p></div>
+        <div class="kicker">GET STARTED</div>
+        <h3>From install to production services</h3>
+        <p>Start with prebuilt images or build your own firmware. Then configure networking, access the WebDesktop, and deploy the apps your environment needs.</p>
+        <div class="row">
+          <a class="btn btn-primary" href="./get-capos.html">Installation Guide</a>
+          <a class="btn btn-ghost" href="https://github.com/fwerkor/capos/releases" target="_blank" rel="noreferrer">Releases</a>
         </div>
       </div>
       <div class="card">
-        <div class="kicker">QUICK LINKS</div>
-        <h3>快速访问</h3>
+        <div class="kicker">ECOSYSTEM</div>
+        <h3>Developer and user resources</h3>
         <ul>
-          <li><a href="./get-capos.html">下载与安装入口（Get CapOS）</a></li>
-          <li><a href="./docs.html">构建、部署与运维文档</a></li>
-          <li><a href="./community.html">社区支持与贡献方式</a></li>
-          <li><a href="https://github.com/fwerkor/capos/releases" target="_blank" rel="noreferrer">GitHub Releases</a></li>
+          <li>Build and deployment docs</li>
+          <li>App development examples</li>
+          <li>Community support channels</li>
+          <li>Issue tracking and feature requests</li>
         </ul>
       </div>
     </section>
 
     <section class="section">
       <div class="cta">
-        <h3>准备部署到 www.capos.org？</h3>
-        <p class="desc">该站点为纯静态多页面结构（HTML/CSS/JS），便于低成本托管与长期维护，也方便后续接入文档系统或下载镜像索引。</p>
+        <h3>Ready to use CapOS?</h3>
+        <p class="desc">Download a build, launch your first node, and start shaping your own open server platform.</p>
         <div class="row">
-          <a class="btn btn-primary" href="./get-capos.html">查看部署入口</a>
-          <a class="btn btn-ghost" href="https://github.com/fwerkor/capos" target="_blank" rel="noreferrer">github.com/fwerkor/capos</a>
+          <a class="btn btn-primary" href="./get-capos.html">Get CapOS</a>
+          <a class="btn btn-ghost" href="./community.html">Join Community</a>
         </div>
       </div>
     </section>

--- a/website/script.js
+++ b/website/script.js
@@ -1,0 +1,9 @@
+const topBtn = document.getElementById('top');
+if (topBtn) {
+  window.addEventListener('scroll', () => {
+    topBtn.classList.toggle('show', window.scrollY > 420);
+  });
+  topBtn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+}

--- a/website/script.js
+++ b/website/script.js
@@ -7,3 +7,31 @@ if (topBtn) {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   });
 }
+
+const menuToggle = document.querySelector('.mobile-menu-toggle');
+const mobileNav = document.getElementById('mobileNav');
+
+if (menuToggle && mobileNav) {
+  menuToggle.addEventListener('click', () => {
+    const willOpen = !mobileNav.classList.contains('open');
+    mobileNav.classList.toggle('open', willOpen);
+    mobileNav.hidden = !willOpen;
+    menuToggle.setAttribute('aria-expanded', String(willOpen));
+  });
+
+  mobileNav.querySelectorAll('a').forEach((a) => {
+    a.addEventListener('click', () => {
+      mobileNav.classList.remove('open');
+      mobileNav.hidden = true;
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 920) {
+      mobileNav.classList.remove('open');
+      mobileNav.hidden = true;
+      menuToggle.setAttribute('aria-expanded', 'false');
+    }
+  });
+}

--- a/website/styles.css
+++ b/website/styles.css
@@ -99,3 +99,36 @@ footer { margin-top: 48px; border-top: 1px solid var(--line); padding: 24px 0 30
   .split { grid-template-columns: 1fr; }
   .table-like div { grid-template-columns: 1fr; }
 }
+
+.mobile-menu-toggle {
+  display: none;
+  border: 1px solid var(--line);
+  background: #0f1a33;
+  color: var(--text);
+  border-radius: 10px;
+  padding: .58rem .8rem;
+  font-weight: 600;
+}
+.mobile-nav {
+  display: none;
+  position: absolute;
+  left: 4vw;
+  right: 4vw;
+  top: calc(100% + 8px);
+  background: #0b1327;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: .6rem;
+  z-index: 30;
+  box-shadow: 0 18px 40px rgba(0,0,0,.35);
+}
+.mobile-nav.open { display: block; }
+.mobile-menu { display: grid; gap: .25rem; margin-bottom: .45rem; }
+.mobile-menu a { color: var(--text); text-decoration: none; padding: .55rem .65rem; border-radius: 8px; }
+.mobile-menu a:hover, .mobile-menu a.active { background: rgba(255,255,255,.07); }
+
+@media (max-width: 920px) {
+  .topbar-inner { position: relative; }
+  .header-github { display: none; }
+  .mobile-menu-toggle { display: inline-flex; }
+}

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,101 @@
+:root {
+  --bg: #060b16;
+  --bg-soft: #0c1428;
+  --panel: #111c36;
+  --line: #23335d;
+  --text: #ecf3ff;
+  --muted: #a6b6d8;
+  --primary: #4ec7ff;
+  --secondary: #8f6bff;
+  --ok: #8df8c9;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 15% -10%, #1a2950 0%, transparent 48%),
+    radial-gradient(circle at 90% -10%, #2e1d5a 0%, transparent 42%),
+    var(--bg);
+}
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: .08;
+  background-image: radial-gradient(#fff 0.6px, transparent 0.6px);
+  background-size: 5px 5px;
+}
+.container { width: min(1160px, 92vw); margin: 0 auto; }
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  border-bottom: 1px solid var(--line);
+  backdrop-filter: blur(8px);
+  background: rgba(5, 10, 19, 0.78);
+}
+.topbar-inner { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 13px 0; }
+.brand { display: inline-flex; align-items: center; text-decoration: none; color: var(--text); font-weight: 800; letter-spacing: .2px; }
+.brand-dot { width: 11px; height: 11px; border-radius: 999px; margin-right: 10px; background: linear-gradient(135deg, var(--primary), var(--secondary)); box-shadow: 0 0 22px rgba(78,199,255,.8); }
+.menu { display: flex; align-items: center; gap: .8rem; flex-wrap: wrap; }
+.menu a { color: var(--muted); text-decoration: none; font-size: .95rem; padding: .35rem .55rem; border-radius: 8px; }
+.menu a:hover, .menu a.active { color: var(--text); background: rgba(255,255,255,.05); }
+.btn { display: inline-flex; align-items: center; justify-content: center; gap: .4rem; border-radius: 10px; text-decoration: none; padding: .62rem 1rem; font-weight: 600; border: 1px solid var(--line); }
+.btn-primary { color: #081122; background: linear-gradient(135deg, #77e8ff, #74b4ff); border-color: #8ad7ff; }
+.btn-ghost { color: var(--text); }
+.btn-ghost:hover { border-color: var(--primary); color: var(--primary); }
+.hero { padding: 78px 0 42px; }
+.badge { display: inline-block; color: var(--primary); border: 1px solid rgba(78,199,255,.4); padding: 5px 10px; border-radius: 999px; font-family: "JetBrains Mono", monospace; font-size: .82rem; }
+h1 { margin: 14px 0 12px; font-size: clamp(2.2rem, 5.8vw, 4.6rem); line-height: 1.05; letter-spacing: -.4px; }
+.gradient { background: linear-gradient(135deg, #adf4ff 8%, var(--primary) 42%, #9a84ff 88%); -webkit-background-clip: text; color: transparent; }
+.lead { margin: 0; color: var(--muted); line-height: 1.8; max-width: 880px; }
+.row { display: flex; gap: .8rem; flex-wrap: wrap; margin-top: 22px; }
+.panel {
+  margin-top: 26px;
+  background: linear-gradient(180deg, #0d1730 0%, #091124 100%);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 20px 55px rgba(0, 0, 0, .32);
+}
+.term-head { display: flex; align-items: center; gap: 7px; border-bottom: 1px solid var(--line); padding: 10px 13px; }
+.term-head span { width: 10px; height: 10px; border-radius: 999px; background: #374c7d; }
+.term-head code { margin-left: 8px; color: var(--muted); font-family: "JetBrains Mono", monospace; }
+pre { margin: 0; padding: 14px; overflow-x: auto; color: var(--ok); font-size: .93rem; line-height: 1.65; font-family: "JetBrains Mono", monospace; }
+.section { padding: 54px 0 12px; }
+.section h2 { margin: 0 0 16px; font-size: clamp(1.45rem, 2.8vw, 2.2rem); }
+.section p.desc { color: var(--muted); line-height: 1.75; max-width: 900px; margin: 0 0 18px; }
+.grid { display: grid; gap: 14px; }
+.grid-3 { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.grid-2 { grid-template-columns: repeat(auto-fit, minmax(290px, 1fr)); }
+.card { border: 1px solid var(--line); border-radius: 12px; padding: 16px; background: linear-gradient(180deg, #0e1a34, #0b1429); }
+.card h3 { margin: 0 0 8px; font-size: 1.06rem; }
+.card p, .card li { color: var(--muted); line-height: 1.7; margin: 0; }
+.card ul { margin: 0; padding-left: 1.05rem; }
+.split { display: grid; gap: 14px; grid-template-columns: 1.2fr .8fr; }
+.timeline { display: grid; gap: 12px; }
+.timeline div { border-left: 2px solid #39508b; padding: 4px 0 4px 13px; }
+.timeline b { color: #9ec0ff; font-family: "JetBrains Mono", monospace; font-size: .86rem; }
+.timeline p { color: var(--muted); margin: 6px 0 0; line-height: 1.65; }
+.cta { margin-top: 24px; border: 1px solid var(--line); background: linear-gradient(120deg, #101f3f, #1a2050); border-radius: 14px; padding: 18px; }
+.cta h3 { margin: 0 0 8px; }
+footer { margin-top: 48px; border-top: 1px solid var(--line); padding: 24px 0 30px; color: var(--muted); }
+.footer-inner { display: flex; gap: 12px; justify-content: space-between; flex-wrap: wrap; }
+.footer-inner a { color: var(--primary); text-decoration: none; }
+#top { position: fixed; right: 18px; bottom: 16px; width: 42px; height: 42px; border-radius: 999px; border: 1px solid var(--line); color: var(--text); background: #101c39; display: none; cursor: pointer; }
+#top.show { display: inline-block; }
+.kicker { color: var(--primary); font-family: "JetBrains Mono", monospace; font-size: .84rem; letter-spacing: .35px; margin-bottom: 8px; }
+.table-like { border: 1px solid var(--line); border-radius: 12px; overflow: hidden; }
+.table-like div { display: grid; grid-template-columns: 1fr 2fr; border-bottom: 1px solid var(--line); }
+.table-like div:last-child { border-bottom: 0; }
+.table-like strong, .table-like span { padding: 12px 14px; }
+.table-like strong { background: #101c36; }
+.table-like span { color: var(--muted); }
+@media (max-width: 920px) {
+  .menu { display: none; }
+  .split { grid-template-columns: 1fr; }
+  .table-like div { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
### Motivation
- Replace the previous single/fragmented site with a clearer, multi-page static site to better present CapOS as an open-source NAS / lightweight server OS. 
- Strengthen product messaging (ecosystem, extensibility, lightweight footprint, WebDesktop usability, security) based on the project README and by referencing Kali's information architecture for navigation and page scope. 

### Description
- Add four new content pages: `website/get-capos.html`, `website/docs.html`, `website/community.html`, and `website/about.html`, and update `website/index.html` to a cohesive multi-page layout. 
- Add a shared stylesheet `website/styles.css` implementing the dark neon/console-inspired visual system and responsive layout, and `website/script.js` implementing a back-to-top interaction. 
- Improve copy across pages to explicitly describe CapOS capabilities (OpenWrt base, WebDesktop, multi-arch compatibility, typical deployment scenarios and ports) and include prominent GitHub/Release CTAs. 

### Testing
- Launched a local static server with `python3 -m http.server --directory website` and verified HTTP 200 responses for `index.html`, `get-capos.html`, `docs.html`, `community.html`, and `about.html`. (All pages returned 200.)
- Captured visual verification screenshots via Playwright for the homepage and Get page (artifacts: `artifacts/capos-home-v2.png`, `artifacts/capos-get-v2.png`), which rendered successfully. 
- Performed a lightweight content/readme alignment check by reading `README.md` and using the Kali homepage as an IA reference via an HTTP fetch for inspiration; no failures in automated checks occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699079a3ce4c8327b5ef5fd2ac5fe19b)