### PR TITLE
website: add robots.txt for crawler directives

### DIFF
--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+
+# Block crawling of common temporary/system paths if they appear in future
+Disallow: /cgi-bin/
+Disallow: /tmp/


### PR DESCRIPTION
### Motivation
- Provide a baseline `robots.txt` for the `website` to allow public pages to be crawled while proactively blocking common temporary/system paths.

### Description
- Add `website/robots.txt` containing `User-agent: *`, `Allow: /`, and `Disallow` rules for `/cgi-bin/` and `/tmp/`.

### Testing
- Verified the new file exists and its contents with `nl -ba website/robots.txt` and confirmed the file is present in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699a785c858c8327a478453ea3e7ae08)