### PR TITLE
docs: move Source Code Access into Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Learn more at our [Wiki](https://github.com/fwerkor/capos/wiki/User-guide).
 
 As an open-source project, CapOS encourages professional developers to contribute to its improvement and to develop applications for it.
 
+### Source Code Access
+
+To make repository access more convenient for users in different regions, CapOS provides the following source code repository endpoints:
+
+* **Primary repository:** https://github.com/fwerkor/capos
+* **Read-only mirror (for users in Mainland China):** https://gitcode.com/fwerkor/capos
+
+Please submit issues, discussions, and pull requests through the GitHub primary repository.
+
 Learn more at our [Wiki](https://github.com/fwerkor/capos/wiki/Developer-guide).
 
 ### Compile CapOS


### PR DESCRIPTION
### Motivation
- Move the repository access guidance into the Development section so it appears in the appropriate developer context per feedback.

### Description
- Remove the standalone top-level `Source Code Access` section and add `### Source Code Access` as a subsection under `## Development`, preserving the primary and mirror endpoints and the instruction to file issues/discussions/PRs via GitHub.

### Testing
- Verified the `README.md` diff locally and committed the update; both verification and commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa0c5cbbc83238defd0b09c73fa55)