### PR TITLE
feat(repo-worker): beautify repository directory browsing page

### DIFF
--- a/website/repo/worker.js
+++ b/website/repo/worker.js
@@ -256,7 +256,7 @@ footer {
   html += `</tbody>
     </table>
   </section>
-  <footer>Served by Cloudflare Worker</footer>
+  <footer>Served by CapOS Team（capos.top）</footer>
 </main>
 </body>
 </html>`;

--- a/website/repo/worker.js
+++ b/website/repo/worker.js
@@ -210,6 +210,14 @@ footer {
   font-size: 0.82rem;
   color: var(--muted);
 }
+.footer-link {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 65%, transparent);
+}
+.footer-link:hover {
+  text-decoration-color: currentColor;
+}
 @media (max-width: 640px) {
   th.col-size,
   td.col-size,
@@ -256,7 +264,7 @@ footer {
   html += `</tbody>
     </table>
   </section>
-  <footer>Served by CapOS Team（capos.top）</footer>
+  <footer>Served by <a class="footer-link" href="https://capos.top">CapOS Project</a></footer>
 </main>
 </body>
 </html>`;


### PR DESCRIPTION
### Motivation
- Improve the default Cloudflare Worker directory index from a plain list to a modern, readable UI for easier repository navigation.
- Surface useful file metadata (size and last modified) to help users understand listing contents at-a-glance.
- Provide a responsive, dark-mode friendly layout so the index looks good on desktop and mobile.

### Description
- Replace the simple `<ul>` index with a card/table layout and scoped CSS variables for light/dark themes and responsive behavior in `website/repo/worker.js`.
- Add `formatBytes` and `formatDate` helpers and compute `directories` and `files` arrays with sorting to populate `Size` and `Last Modified` columns.
- Preserve parent/dir/file navigation and add an item-count summary and empty-directory state message in the rendered HTML.
- Update the directory response `Content-Security-Policy` to allow inline styles and export `renderDirectoryIndex` for local preview/testing.

### Testing
- `node --check website/repo/worker.js` was run and succeeded.
- Generated a local preview HTML by importing `renderDirectoryIndex` with `node --input-type=module` and writing `website/repo/preview.html`, which completed successfully.
- Served the preview with `python3 -m http.server` and captured a visual screenshot using Playwright for manual verification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a13ba09a408323bbdef5434cf2dfa6)