### PR TITLE
Update repository link on Get CapOS page

### DIFF
--- a/website/get-capos.html
+++ b/website/get-capos.html
@@ -44,7 +44,7 @@
       <p class="lead">Use official builds for a fast start, or compile your own firmware for architecture-specific optimization and advanced customization.</p>
       <div class="row">
         <a class="btn btn-primary" href="https://github.com/fwerkor/capos/releases" target="_blank" rel="noreferrer">GitHub Releases</a>
-        <a class="btn btn-ghost" href="https://repo.fwerkor.com/capos" target="_blank" rel="noreferrer">FWERKOR Repository</a>
+        <a class="btn btn-ghost" href="https://repo.capos.top" target="_blank" rel="noreferrer">Repository</a>
       </div>
     </section>
 


### PR DESCRIPTION
### Motivation
- Replace the old FWERKOR-branded repository CTA with a neutral label and point it to the canonical `https://repo.capos.top` from the Get CapOS hero section.

### Description
- Updated the anchor in `website/get-capos.html` to change the href from `https://repo.fwerkor.com/capos` to `https://repo.capos.top` and the link text from `FWERKOR Repository` to `Repository`.

### Testing
- Verified the updated HTML with `nl -ba website/get-capos.html`, served the site using `python -m http.server --directory website` and captured a Playwright screenshot of `http://127.0.0.1:8000/get-capos.html`, and committed the change with `git`; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a153eaf2ec83238d303bc23b90d1a3)