### PR TITLE
webpanel: prioritize desktop space with collapsible controls

### DIFF
--- a/package/capos/capos-webpanel/htdocs/index.html
+++ b/package/capos/capos-webpanel/htdocs/index.html
@@ -6,18 +6,14 @@
     <title>CapOS WebDesktop</title>
     <style>
       :root {
-        --bg: #efe8dc;
-        --surface: rgba(255, 249, 239, 0.92);
-        --surface-strong: #fffdf8;
-        --ink: #162028;
-        --muted: #687782;
-        --line: #d8cfbe;
-        --accent: #cf5b34;
-        --accent-strong: #b64320;
-        --accent-soft: #ffe2d4;
-        --success: #1f7a54;
+        --bg: #ebe3d6;
+        --surface: rgba(255, 251, 244, 0.96);
+        --ink: #15202a;
+        --muted: #65727d;
+        --line: #ddd2c1;
+        --accent: #c75531;
         --danger: #b53b33;
-        --shadow: 0 24px 60px rgba(37, 44, 51, 0.12);
+        --shadow: 0 16px 36px rgba(23, 30, 36, 0.15);
       }
 
       * {
@@ -30,109 +26,33 @@
         min-height: 100%;
         font-family: "Segoe UI", "PingFang SC", sans-serif;
         color: var(--ink);
-        background:
-          radial-gradient(circle at top left, rgba(255, 246, 221, 0.85), transparent 35%),
-          radial-gradient(circle at right, rgba(220, 128, 85, 0.12), transparent 28%),
-          linear-gradient(180deg, #f5efe4 0%, #ebe2d2 100%);
+        background: linear-gradient(180deg, #f3ecdf 0%, var(--bg) 100%);
       }
 
-      body {
-        padding: 20px;
+      button,
+      .link-button,
+      input {
+        font: inherit;
       }
 
-      .app {
-        display: none;
-        grid-template-rows: auto 1fr;
-        gap: 18px;
-        min-height: calc(100vh - 40px);
-      }
-
-      .app.ready {
-        display: grid;
-      }
-
-      .topbar {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 16px;
-        padding: 18px 22px;
-        border: 1px solid var(--line);
-        border-radius: 24px;
-        background: rgba(255, 251, 244, 0.9);
-        box-shadow: var(--shadow);
-        backdrop-filter: blur(14px);
-      }
-
-      .brand {
-        display: flex;
-        align-items: center;
-        gap: 16px;
-      }
-
-      .brand-mark {
-        width: 52px;
-        height: 52px;
-        border-radius: 18px;
-        background: linear-gradient(135deg, #da6a42, #f1b17a);
-        display: grid;
-        place-items: center;
-        color: white;
-        font-weight: 800;
-        letter-spacing: 0.08em;
-      }
-
-      .brand h1,
-      .brand p {
-        margin: 0;
-      }
-
-      .brand h1 {
-        font-size: 22px;
-      }
-
-      .brand p {
-        color: var(--muted);
-        font-size: 13px;
-      }
-
-      .topbar-actions {
-        display: flex;
-        align-items: center;
-        flex-wrap: wrap;
-        justify-content: flex-end;
-        gap: 10px;
-      }
-
-      .pill,
       button,
       .link-button {
         border: none;
         border-radius: 999px;
-        padding: 11px 16px;
-        font: inherit;
+        padding: 8px 14px;
         cursor: pointer;
-        transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+        text-decoration: none;
+        transition: transform 0.14s ease, opacity 0.14s ease;
       }
 
-      .pill:hover,
       button:hover,
       .link-button:hover {
         transform: translateY(-1px);
       }
 
-      .pill {
-        background: var(--accent-soft);
-        color: var(--accent-strong);
-        font-weight: 700;
-      }
-
-      .link-button,
       .primary {
         background: var(--accent);
-        color: white;
-        text-decoration: none;
-        box-shadow: 0 12px 24px rgba(207, 91, 52, 0.24);
+        color: #fff;
       }
 
       .secondary {
@@ -146,223 +66,22 @@
         color: var(--danger);
       }
 
-      .shell {
-        display: grid;
-        grid-template-columns: 360px 1fr;
-        gap: 18px;
-        min-height: 0;
-      }
-
-      .sidebar,
-      .desktop {
-        min-height: 0;
-      }
-
-      .stack {
-        display: grid;
-        gap: 18px;
-      }
-
-      .panel {
-        border: 1px solid var(--line);
-        border-radius: 24px;
-        background: var(--surface);
-        box-shadow: var(--shadow);
-        overflow: hidden;
-      }
-
-      .panel-head {
-        padding: 18px 22px 10px;
-      }
-
-      .panel-head h2,
-      .panel-head p {
-        margin: 0;
-      }
-
-      .panel-head h2 {
-        font-size: 18px;
-      }
-
-      .panel-head p {
-        color: var(--muted);
-        margin-top: 6px;
-        font-size: 13px;
-      }
-
-      .panel-body {
-        padding: 0 22px 22px;
-      }
-
-      .apps {
-        display: grid;
-        gap: 12px;
-      }
-
-      .app-card {
-        background: var(--surface-strong);
-        border: 1px solid var(--line);
-        border-radius: 18px;
-        padding: 16px;
-        display: grid;
-        gap: 12px;
-      }
-
-      .app-card h3,
-      .app-card p {
-        margin: 0;
-      }
-
-      .app-card p {
-        color: var(--muted);
-        font-size: 13px;
-        line-height: 1.45;
-      }
-
-      .app-meta {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-      }
-
-      .chip {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        border-radius: 999px;
-        padding: 6px 10px;
-        background: #fff;
-        border: 1px solid var(--line);
-        color: var(--muted);
-        font-size: 12px;
-        font-weight: 700;
-      }
-
-      .chip.running {
-        color: var(--success);
-        background: rgba(31, 122, 84, 0.1);
-        border-color: rgba(31, 122, 84, 0.2);
-      }
-
-      .chip.stopped {
-        color: var(--danger);
-        background: rgba(181, 59, 51, 0.1);
-        border-color: rgba(181, 59, 51, 0.2);
-      }
-
-      .chip.portmap {
-        cursor: pointer;
-      }
-
-      .actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-      }
-
-      .actions button {
-        padding: 9px 13px;
-        font-size: 13px;
-      }
-
-      .desktop-frame {
-        width: 100%;
-        height: 100%;
-        min-height: 720px;
-        border: none;
-        display: block;
-        background: #f7f6f1;
-      }
-
-      .desktop-shell {
-        display: grid;
-        grid-template-rows: auto 1fr;
-        min-height: 0;
-        height: 100%;
-      }
-
-      .desktop-toolbar {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 10px;
-        padding: 18px 22px;
-        border-bottom: 1px solid var(--line);
-      }
-
-      .desktop-toolbar h2,
-      .desktop-toolbar p {
-        margin: 0;
-      }
-
-      .desktop-toolbar p {
-        color: var(--muted);
-        font-size: 13px;
-        margin-top: 5px;
-      }
-
-      .upload-box {
-        display: grid;
-        gap: 12px;
-      }
-
-      input[type="text"],
-      input[type="password"],
-      input[type="file"] {
-        width: 100%;
-        padding: 13px 14px;
-        border-radius: 14px;
-        border: 1px solid var(--line);
-        background: #fff;
-        color: var(--ink);
-        font: inherit;
-      }
-
-      .status {
-        position: fixed;
-        right: 20px;
-        bottom: 20px;
-        max-width: 360px;
-        padding: 14px 16px;
-        border-radius: 16px;
-        background: rgba(22, 32, 40, 0.92);
-        color: white;
-        box-shadow: var(--shadow);
-        opacity: 0;
-        transform: translateY(10px);
-        pointer-events: none;
-        transition: opacity 0.2s ease, transform 0.2s ease;
-      }
-
-      .status.visible {
-        opacity: 1;
-        transform: translateY(0);
-      }
-
-      .inspection {
-        background: #171d22;
-        color: #d7e1e8;
-        border-radius: 16px;
-        padding: 14px;
-        overflow: auto;
-        font: 12px/1.5 ui-monospace, monospace;
-      }
-
       .login {
         display: grid;
         place-items: center;
-        min-height: calc(100vh - 40px);
+        min-height: 100vh;
+        padding: 20px;
       }
 
       .login-card {
         width: min(420px, 100%);
         border: 1px solid rgba(255, 255, 255, 0.5);
-        border-radius: 28px;
-        background: rgba(255, 250, 240, 0.92);
+        border-radius: 22px;
+        background: var(--surface);
         box-shadow: var(--shadow);
-        padding: 28px;
+        padding: 24px;
         display: grid;
-        gap: 16px;
+        gap: 14px;
       }
 
       .login-card h1,
@@ -374,9 +93,280 @@
         color: var(--muted);
       }
 
-      @media (max-width: 1080px) {
-        .shell {
-          grid-template-columns: 1fr;
+      input[type="text"],
+      input[type="password"],
+      input[type="file"] {
+        width: 100%;
+        padding: 11px 13px;
+        border-radius: 12px;
+        border: 1px solid var(--line);
+        background: #fff;
+      }
+
+      .app {
+        display: none;
+        min-height: 100vh;
+      }
+
+      .app.ready {
+        display: block;
+      }
+
+      .workspace {
+        position: relative;
+        min-height: 100vh;
+      }
+
+      .desktop {
+        height: 100vh;
+      }
+
+      .desktop-frame {
+        width: 100%;
+        height: 100%;
+        border: none;
+        display: block;
+        background: #f7f6f1;
+      }
+
+      .topbar {
+        position: fixed;
+        z-index: 20;
+        top: 12px;
+        left: 12px;
+        right: 12px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 14px;
+        border-radius: 16px;
+        border: 1px solid var(--line);
+        background: rgba(255, 251, 244, 0.9);
+        backdrop-filter: blur(10px);
+        box-shadow: var(--shadow);
+      }
+
+      .topbar-main {
+        display: grid;
+        min-width: 0;
+      }
+
+      .topbar-main strong {
+        font-size: 14px;
+      }
+
+      .topbar-main span {
+        color: var(--muted);
+        font-size: 12px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .topbar-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        padding: 7px 12px;
+        font-size: 13px;
+        font-weight: 700;
+        background: rgba(199, 85, 49, 0.12);
+        color: var(--accent);
+      }
+
+      .control-drawer {
+        position: fixed;
+        top: 72px;
+        right: 12px;
+        bottom: 12px;
+        width: min(360px, calc(100vw - 24px));
+        border: 1px solid var(--line);
+        border-radius: 18px;
+        background: var(--surface);
+        box-shadow: var(--shadow);
+        padding: 14px;
+        display: grid;
+        grid-template-rows: auto 1fr;
+        gap: 12px;
+        z-index: 18;
+        transform: translateX(calc(100% + 18px));
+        transition: transform 0.2s ease;
+      }
+
+      .control-drawer.open {
+        transform: translateX(0);
+      }
+
+      .drawer-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .drawer-head h2,
+      .drawer-head p {
+        margin: 0;
+      }
+
+      .drawer-head h2 {
+        font-size: 16px;
+      }
+
+      .drawer-head p {
+        margin-top: 3px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .drawer-content {
+        overflow: auto;
+        display: grid;
+        gap: 12px;
+        padding-right: 4px;
+      }
+
+      .panel {
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.75);
+        padding: 12px;
+        display: grid;
+        gap: 10px;
+      }
+
+      .panel h3,
+      .panel p {
+        margin: 0;
+      }
+
+      .panel h3 {
+        font-size: 15px;
+      }
+
+      .panel p {
+        font-size: 12px;
+        color: var(--muted);
+      }
+
+      .apps {
+        display: grid;
+        gap: 10px;
+      }
+
+      .app-card {
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: #fff;
+        padding: 10px;
+        display: grid;
+        gap: 8px;
+      }
+
+      .app-card h4,
+      .app-card p {
+        margin: 0;
+      }
+
+      .app-card h4 {
+        font-size: 14px;
+      }
+
+      .app-card p {
+        font-size: 12px;
+        color: var(--muted);
+      }
+
+      .app-meta,
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+
+      .chip {
+        display: inline-flex;
+        border-radius: 999px;
+        border: 1px solid var(--line);
+        padding: 4px 8px;
+        background: #fff;
+        color: var(--muted);
+        font-size: 11px;
+        font-weight: 700;
+      }
+
+      .chip.running {
+        color: #1f7a54;
+      }
+
+      .chip.stopped {
+        color: var(--danger);
+      }
+
+      .chip.portmap {
+        cursor: pointer;
+      }
+
+      .actions button {
+        font-size: 12px;
+        padding: 6px 10px;
+      }
+
+      .upload-box {
+        display: grid;
+        gap: 9px;
+      }
+
+      .inspection {
+        background: #171d22;
+        color: #d7e1e8;
+        border-radius: 10px;
+        padding: 10px;
+        overflow: auto;
+        max-height: 180px;
+        font: 11px/1.4 ui-monospace, monospace;
+      }
+
+      .status {
+        position: fixed;
+        right: 14px;
+        bottom: 14px;
+        max-width: 320px;
+        padding: 12px 14px;
+        border-radius: 12px;
+        background: rgba(22, 32, 40, 0.92);
+        color: #fff;
+        box-shadow: var(--shadow);
+        opacity: 0;
+        transform: translateY(8px);
+        pointer-events: none;
+        transition: opacity 0.2s ease, transform 0.2s ease;
+        z-index: 22;
+      }
+
+      .status.visible {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      @media (max-width: 720px) {
+        .topbar {
+          flex-wrap: wrap;
+        }
+
+        .topbar-actions {
+          width: 100%;
+          justify-content: flex-end;
+        }
+
+        .control-drawer {
+          top: 118px;
         }
       }
     </style>
@@ -395,62 +385,57 @@
     </section>
 
     <section class="app" id="appShell">
-      <header class="topbar">
-        <div class="brand">
-          <div class="brand-mark">CAP</div>
-          <div>
-            <h1>CapOS WebDesktop</h1>
-            <p id="sessionSummary">正在同步你的应用环境…</p>
+      <div class="workspace">
+        <header class="topbar">
+          <div class="topbar-main">
+            <strong>CapOS WebDesktop</strong>
+            <span id="sessionSummary">正在同步你的应用环境…</span>
+            <span id="desktopHint">选择一个已安装应用作为你的桌面应用。</span>
           </div>
-        </div>
-        <div class="topbar-actions">
-          <span class="pill" id="userBadge">访客</span>
-          <a class="link-button" href="/cgi-bin/luci/" id="luciLink" style="display:none">LuCI</a>
-          <button class="secondary" id="refreshBtn" type="button">刷新</button>
-          <button class="danger" id="logoutBtn" type="button">退出</button>
-        </div>
-      </header>
+          <div class="topbar-actions">
+            <span class="pill" id="userBadge">访客</span>
+            <a class="secondary link-button" href="/cgi-bin/luci/" id="luciLink" style="display:none">LuCI</a>
+            <button class="secondary" id="toggleDrawerBtn" type="button">管理</button>
+            <button class="danger" id="logoutBtn" type="button">退出</button>
+          </div>
+        </header>
 
-      <div class="shell">
-        <aside class="sidebar stack">
-          <section class="panel">
-            <div class="panel-head">
-              <h2>应用库</h2>
-              <p>这里只显示当前登录用户自己的应用。</p>
+        <main class="desktop">
+          <iframe class="desktop-frame" id="desktopFrame" src="/cgi-bin/cap/app"></iframe>
+        </main>
+
+        <aside class="control-drawer" id="controlDrawer">
+          <div class="drawer-head">
+            <div>
+              <h2>控制面板</h2>
+              <p>保持极简，只在需要时展开。</p>
             </div>
-            <div class="panel-body">
+            <button class="secondary" id="closeDrawerBtn" type="button">收起</button>
+          </div>
+
+          <div class="drawer-content">
+            <section class="panel">
+              <div>
+                <h3>应用库</h3>
+                <p>仅显示当前登录用户自己的应用。</p>
+              </div>
               <div class="apps" id="appsList"></div>
-            </div>
-          </section>
+            </section>
 
-          <section class="panel">
-            <div class="panel-head">
-              <h2>上传安装 CPK</h2>
-              <p>系统面板只负责本地上传安装，不内建应用商店。</p>
-            </div>
-            <div class="panel-body">
+            <section class="panel">
+              <div>
+                <h3>上传安装 CPK</h3>
+                <p>支持本地上传后预检与安装。</p>
+              </div>
               <div class="upload-box">
                 <input id="cpkFile" type="file" accept=".cpk,.tar.gz,.tgz" />
                 <button class="primary" id="uploadBtn" type="button">上传并预检</button>
                 <button class="secondary" id="installBtn" type="button" disabled>确认安装</button>
                 <div class="inspection" id="inspectionBox">等待上传 CPK…</div>
               </div>
-            </div>
-          </section>
+            </section>
+          </div>
         </aside>
-
-        <main class="desktop">
-          <section class="panel desktop-shell">
-            <div class="desktop-toolbar">
-              <div>
-                <h2>桌面应用</h2>
-                <p id="desktopHint">选择一个已安装应用作为你的桌面应用。</p>
-              </div>
-              <button class="secondary" id="reloadDesktopBtn" type="button">重载桌面</button>
-            </div>
-            <iframe class="desktop-frame" id="desktopFrame" src="/cgi-bin/cap/app"></iframe>
-          </section>
-        </main>
       </div>
     </section>
 
@@ -468,6 +453,7 @@
 
       const loginView = $("loginView");
       const appShell = $("appShell");
+      const controlDrawer = $("controlDrawer");
       const appsList = $("appsList");
       const sessionSummary = $("sessionSummary");
       const userBadge = $("userBadge");
@@ -514,7 +500,7 @@
 
       function renderApps() {
         if (!state.apps.length) {
-          appsList.innerHTML = `<div class="app-card"><h3>还没有已安装应用</h3><p>上传一个 CPK 并通过预检后，就可以在这里看到它。</p></div>`;
+          appsList.innerHTML = `<div class="app-card"><h4>还没有已安装应用</h4><p>上传 CPK 之后将在这里显示。</p></div>`;
           return;
         }
 
@@ -535,7 +521,7 @@
             return `
               <article class="app-card">
                 <div>
-                  <h3>${nickname}</h3>
+                  <h4>${nickname}</h4>
                   <p>${item.app.description || "这个应用还没有提供描述。"}</p>
                 </div>
                 <div class="app-meta">
@@ -586,9 +572,7 @@
       async function loadDesktop() {
         const data = await api("/desktop");
         state.desktop = data;
-        desktopHint.textContent = data.app
-          ? `当前桌面应用：${data.app}`
-          : "选择一个已安装应用作为你的桌面应用。";
+        desktopHint.textContent = data.app ? `当前桌面应用：${data.app}` : "请选择一个已安装应用作为桌面应用。";
         refreshDesktopFrame();
       }
 
@@ -598,6 +582,9 @@
         }
         await Promise.all([loadApps(), loadDesktop()]);
       }
+
+      $("toggleDrawerBtn").addEventListener("click", () => controlDrawer.classList.toggle("open"));
+      $("closeDrawerBtn").addEventListener("click", () => controlDrawer.classList.remove("open"));
 
       $("loginForm").addEventListener("submit", async (event) => {
         event.preventDefault();
@@ -627,20 +614,10 @@
           state.desktop = null;
           state.upload = null;
           inspectionBox.textContent = "等待上传 CPK…";
+          controlDrawer.classList.remove("open");
           setAuthedUi(false);
         }
       });
-
-      $("refreshBtn").addEventListener("click", async () => {
-        try {
-          await refreshAll();
-          showStatus("已刷新应用状态");
-        } catch (error) {
-          showStatus(error.message, "error");
-        }
-      });
-
-      $("reloadDesktopBtn").addEventListener("click", refreshDesktopFrame);
 
       appsList.addEventListener("click", async (event) => {
         const button = event.target.closest("button[data-action]");
@@ -749,7 +726,7 @@
             headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
             body: new URLSearchParams({ upload_id: state.upload.id }),
           });
-          inspectionBox.textContent = "安装成功，可以在左侧应用库中查看。";
+          inspectionBox.textContent = "安装成功，可以在应用库中查看。";
           $("installBtn").disabled = true;
           $("cpkFile").value = "";
           state.upload = null;

--- a/package/capos/capos-webpanel/htdocs/index.html
+++ b/package/capos/capos-webpanel/htdocs/index.html
@@ -115,10 +115,11 @@
       .workspace {
         position: relative;
         min-height: 100vh;
+        padding-top: var(--workspace-top, 84px);
       }
 
       .desktop {
-        height: 100vh;
+        height: calc(100vh - var(--workspace-top, 84px));
       }
 
       .desktop-frame {
@@ -183,7 +184,7 @@
 
       .control-drawer {
         position: fixed;
-        top: 72px;
+        top: var(--workspace-top, 84px);
         right: 12px;
         bottom: 12px;
         width: min(360px, calc(100vw - 24px));
@@ -453,6 +454,7 @@
 
       const loginView = $("loginView");
       const appShell = $("appShell");
+      const topbar = document.querySelector(".topbar");
       const controlDrawer = $("controlDrawer");
       const appsList = $("appsList");
       const sessionSummary = $("sessionSummary");
@@ -492,6 +494,12 @@
       function setAuthedUi(authed) {
         loginView.style.display = authed ? "none" : "grid";
         appShell.classList.toggle("ready", authed);
+      }
+
+      function updateViewportOffsets() {
+        const topbarHeight = topbar ? topbar.offsetHeight : 60;
+        const workspaceTop = topbarHeight + 24;
+        document.documentElement.style.setProperty("--workspace-top", `${workspaceTop}px`);
       }
 
       function refreshDesktopFrame() {
@@ -560,6 +568,7 @@
         }`;
         luciLink.style.display = data.session.is_sudo ? "inline-flex" : "none";
         setAuthedUi(true);
+        updateViewportOffsets();
         return true;
       }
 
@@ -573,6 +582,7 @@
         const data = await api("/desktop");
         state.desktop = data;
         desktopHint.textContent = data.app ? `当前桌面应用：${data.app}` : "请选择一个已安装应用作为桌面应用。";
+        updateViewportOffsets();
         refreshDesktopFrame();
       }
 
@@ -585,6 +595,7 @@
 
       $("toggleDrawerBtn").addEventListener("click", () => controlDrawer.classList.toggle("open"));
       $("closeDrawerBtn").addEventListener("click", () => controlDrawer.classList.remove("open"));
+      window.addEventListener("resize", updateViewportOffsets);
 
       $("loginForm").addEventListener("submit", async (event) => {
         event.preventDefault();
@@ -741,6 +752,7 @@
         setAuthedUi(false);
         showStatus(error.message, "error");
       });
+      updateViewportOffsets();
     </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Make the webpanel leaner and give the desktop iframe as much screen real estate as possible while keeping management features available on demand.
- Reduce visual clutter and avoid exposing non-essential buttons by collapsing management controls into a transient UI element.

### Description
- Reworked the UI in `package/capos/capos-webpanel/htdocs/index.html` to a desktop-first layout with a full-viewport iframe and a compact fixed topbar. 
- Replaced the persistent left sidebar with a right-side collapsible control drawer containing the app list and CPK upload/install panels, toggled by a new "管理" button and closable with a drawer control. 
- Removed always-visible refresh/reload controls and adjusted CSS/markup to minimize chrome, simplify cards/chips, and keep app actions and upload flows intact. 
- Kept existing API usage and JS logic for `session`, `apps`, `desktop`, `upload` and `install` operations while adding drawer toggle handlers and small copy/markup tweaks.

### Testing
- `git diff --check` was run and reported no issues. 
- Attempted `xmllint --html --noout package/capos/capos-webpanel/htdocs/index.html` but the tool is not available in the environment, so HTML linting could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1e32b692c83238b00fdf162dcda1e)