### PR TITLE
Add ArgosFS as default CapOS rootfs

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -94,6 +94,7 @@ menu "Target Images"
 	menuconfig TARGET_ROOTFS_ARGOSFS
 		bool "argosfs"
 		default y
+		select TARGET_ROOTFS_INITRAMFS
 		select PACKAGE_argosfs
 		select PACKAGE_kmod-fuse
 		select PACKAGE_libfuse3
@@ -358,11 +359,14 @@ menu "Target Images"
 		int "Root filesystem partition size (in MiB)"
 		depends on USES_ROOTFS_PART || TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_ARGOSFS
 		default 448 if TARGET_mediatek || TARGET_microchipsw
+		default 384 if TARGET_ROOTFS_ARGOSFS
 		default 256 if PACKAGE_podman
 		default 232 if TARGET_loongarch64
 		default 104
 		help
 		  Select the root filesystem partition size.
+		  When ArgosFS is enabled, the default is raised to 384 MiB to
+		  leave room for raw metadata, journal, and normal rootfs growth.
 		  When Podman is enabled, the default is raised to 256 MiB to
 		  accommodate the larger root filesystem footprint.
 

--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -350,6 +350,7 @@ menu "Target Images"
 	config TARGET_KERNEL_PARTSIZE
 		int "Kernel partition size (in MiB)"
 		depends on USES_BOOT_PART
+		default 64 if TARGET_ROOTFS_ARGOSFS
 		default 8 if TARGET_apm821xx_sata
 		default 64 if TARGET_bcm27xx
 		default 128 if TARGET_armsr

--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -77,20 +77,36 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_CPIOGZ
 		bool "cpio.gz"
+		depends on !TARGET_ROOTFS_ARGOSFS
 		default y if USES_CPIOGZ
 		help
 		  Build a compressed cpio archive of the root filesystem.
 
 	config TARGET_ROOTFS_TARGZ
 		bool "tar.gz"
+		depends on !TARGET_ROOTFS_ARGOSFS
 		default y if USES_TARGZ
 		help
 		  Build a compressed tar archive of the root filesystem.
 
 	comment "Root filesystem images"
 
+	menuconfig TARGET_ROOTFS_ARGOSFS
+		bool "argosfs"
+		default y
+		select PACKAGE_argosfs
+		select PACKAGE_kmod-fuse
+		select PACKAGE_libfuse3
+		select PACKAGE_fuse3-utils
+		help
+		  Build an ArgosFS loop/raw root filesystem pool image. This is the
+		  default CapOS root filesystem; /boot or EFI may remain a normal
+		  bootloader-readable filesystem, but runtime / is mounted by ArgosFS
+		  from initramfs.
+
 	menuconfig TARGET_ROOTFS_EROFS
 		bool "erofs"
+		depends on !TARGET_ROOTFS_ARGOSFS
 		default y if USES_EROFS
 		select KERNEL_EROFS_FS
 		help
@@ -108,6 +124,7 @@ menu "Target Images"
 
 	menuconfig TARGET_ROOTFS_EXT4FS
 		bool "ext4"
+		depends on !TARGET_ROOTFS_ARGOSFS
 		default y if USES_EXT4
 		help
 		  Build an ext4 root filesystem.
@@ -152,12 +169,14 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_JFFS2
 		bool "jffs2"
+		depends on !TARGET_ROOTFS_ARGOSFS
 		depends on USES_JFFS2
 		help
 		  Build a JFFS2 root filesystem.
 
 	config TARGET_ROOTFS_JFFS2_NAND
 		bool "jffs2 for NAND"
+		depends on !TARGET_ROOTFS_ARGOSFS
 		default y if USES_JFFS2_NAND
 		depends on USES_JFFS2_NAND
 		help
@@ -165,6 +184,7 @@ menu "Target Images"
 
 	menuconfig TARGET_ROOTFS_SQUASHFS
 		bool "squashfs"
+		depends on !TARGET_ROOTFS_ARGOSFS
 		default y if USES_SQUASHFS
 		help
 		  Build a squashfs root filesystem.
@@ -197,6 +217,7 @@ menu "Target Images"
 
 	menuconfig TARGET_ROOTFS_UBIFS
 		bool "ubifs"
+		depends on !TARGET_ROOTFS_ARGOSFS
 		default y if USES_UBIFS
 		depends on USES_UBIFS
 		help
@@ -233,7 +254,7 @@ menu "Target Images"
 	config GRUB_IMAGES
 		bool "Build GRUB images (Linux x86 or x86_64 host only)"
 		depends on TARGET_x86
-		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS || TARGET_ROOTFS_EROFS
+		depends on TARGET_ROOTFS_ARGOSFS || TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS || TARGET_ROOTFS_EROFS
 		select PACKAGE_grub2
 		select PACKAGE_grub2-bios-setup
 		default y
@@ -241,7 +262,7 @@ menu "Target Images"
 	config GRUB_EFI_IMAGES
 		bool "Build GRUB EFI images"
 		depends on TARGET_x86 || TARGET_armsr || TARGET_loongarch64
-		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS || TARGET_ROOTFS_EROFS
+		depends on TARGET_ROOTFS_ARGOSFS || TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS || TARGET_ROOTFS_EROFS
 		select PACKAGE_grub2 if TARGET_x86
 		select PACKAGE_grub2-efi if TARGET_x86
 		select PACKAGE_grub2-bios-setup if TARGET_x86
@@ -317,7 +338,7 @@ menu "Target Images"
 
 	config TARGET_IMAGES_GZIP
 		bool "GZip images"
-		depends on TARGET_ROOTFS_EXT4FS || TARGET_x86 || TARGET_armsr || TARGET_malta || TARGET_loongarch64
+		depends on TARGET_ROOTFS_ARGOSFS || TARGET_ROOTFS_EXT4FS || TARGET_x86 || TARGET_armsr || TARGET_malta || TARGET_loongarch64
 		default y
 
 	comment "Image Options"
@@ -335,7 +356,7 @@ menu "Target Images"
 
 	config TARGET_ROOTFS_PARTSIZE
 		int "Root filesystem partition size (in MiB)"
-		depends on USES_ROOTFS_PART || TARGET_ROOTFS_EXT4FS
+		depends on USES_ROOTFS_PART || TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_ARGOSFS
 		default 448 if TARGET_mediatek || TARGET_microchipsw
 		default 256 if PACKAGE_podman
 		default 232 if TARGET_loongarch64

--- a/include/image.mk
+++ b/include/image.mk
@@ -222,6 +222,9 @@ ifneq ($(CONFIG_PACKAGE_podman),)
   endif
 endif
 ifneq ($(CONFIG_TARGET_ROOTFS_ARGOSFS),)
+  ifneq ($(shell [ -n "$(CONFIG_TARGET_KERNEL_PARTSIZE)" ] && [ "$(CONFIG_TARGET_KERNEL_PARTSIZE)" -lt 64 ] && echo y),)
+    $(error TARGET_KERNEL_PARTSIZE=$(CONFIG_TARGET_KERNEL_PARTSIZE) MiB is too small for ArgosFS initramfs kernel. Set it to at least 64 MiB or regenerate the config with the updated defaults)
+  endif
   ifneq ($(shell [ -n "$(CONFIG_TARGET_ROOTFS_PARTSIZE)" ] && [ "$(CONFIG_TARGET_ROOTFS_PARTSIZE)" -lt 384 ] && echo y),)
     $(error TARGET_ROOTFS_PARTSIZE=$(CONFIG_TARGET_ROOTFS_PARTSIZE) MiB is too small for ArgosFS. Set it to at least 384 MiB or regenerate the config with the updated defaults)
   endif

--- a/include/image.mk
+++ b/include/image.mk
@@ -359,6 +359,9 @@ define Image/mkfs/argosfs
 		--compression none \
 		--image-size $(ROOTFS_PARTSIZE) \
 		--pool-name capos-root \
+		--defer-journal-flush \
+		--defer-metadata-commit \
+		--defer-data-flush \
 		--force
 	$(STAGING_DIR_HOSTPKG)/bin/argosfs import-tree --backend loop \
 		--images $@ \

--- a/include/image.mk
+++ b/include/image.mk
@@ -112,6 +112,7 @@ EROFSCOMP := lzma,109
 endif
 
 fs-types-$(CONFIG_TARGET_ROOTFS_SQUASHFS) += squashfs
+fs-types-$(CONFIG_TARGET_ROOTFS_ARGOSFS) += argosfs
 fs-types-$(CONFIG_TARGET_ROOTFS_JFFS2) += $(addprefix jffs2-,$(JFFS2_BLOCKSIZE))
 fs-types-$(CONFIG_TARGET_ROOTFS_JFFS2_NAND) += $(addprefix jffs2-nand-,$(NAND_BLOCKSIZE))
 fs-types-$(CONFIG_TARGET_ROOTFS_EXT4FS) += ext4
@@ -339,6 +340,23 @@ define Image/mkfs/targz
 	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
 		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
 		-C $(call mkfs_target_dir,$(1)) . | gzip -9n > $@
+endef
+
+define Image/mkfs/argosfs
+	rm -f $@ $@.disk*
+	$(STAGING_DIR_HOSTPKG)/bin/argosfs mkfs --backend loop \
+		--images $@.disk0,$@.disk1,$@.disk2 \
+		--k 2 --m 1 \
+		--image-size $(ROOTFS_PARTSIZE) \
+		--pool-name capos-root \
+		--force
+	$(STAGING_DIR_HOSTPKG)/bin/argosfs import-tree --backend loop \
+		--images $@.disk0,$@.disk1,$@.disk2 \
+		$(call mkfs_target_dir,$(1)) /
+	$(STAGING_DIR_HOSTPKG)/bin/argosfs preflight-root --backend loop \
+		--images $@.disk0,$@.disk1,$@.disk2 --mode rw
+	tar -C $(dir $@) -cf $@.tar $(notdir $@).disk0 $(notdir $@).disk1 $(notdir $@).disk2
+	mv $@.tar $@
 endef
 
 define Image/Manifest

--- a/include/image.mk
+++ b/include/image.mk
@@ -221,6 +221,11 @@ ifneq ($(CONFIG_PACKAGE_podman),)
     $(error TARGET_ROOTFS_PARTSIZE=$(CONFIG_TARGET_ROOTFS_PARTSIZE) MiB is too small for Podman. Set it to at least 256 MiB or regenerate the config with the updated defaults)
   endif
 endif
+ifneq ($(CONFIG_TARGET_ROOTFS_ARGOSFS),)
+  ifneq ($(shell [ -n "$(CONFIG_TARGET_ROOTFS_PARTSIZE)" ] && [ "$(CONFIG_TARGET_ROOTFS_PARTSIZE)" -lt 384 ] && echo y),)
+    $(error TARGET_ROOTFS_PARTSIZE=$(CONFIG_TARGET_ROOTFS_PARTSIZE) MiB is too small for ArgosFS. Set it to at least 384 MiB or regenerate the config with the updated defaults)
+  endif
+endif
 endif
 
 define Image/pad-root-squashfs
@@ -343,20 +348,20 @@ define Image/mkfs/targz
 endef
 
 define Image/mkfs/argosfs
-	rm -f $@ $@.disk*
+	rm -f $@
 	$(STAGING_DIR_HOSTPKG)/bin/argosfs mkfs --backend loop \
-		--images $@.disk0,$@.disk1,$@.disk2 \
-		--k 2 --m 1 \
+		--images $@ \
+		--k 1 --m 0 \
+		--chunk-size 262144 \
+		--compression none \
 		--image-size $(ROOTFS_PARTSIZE) \
 		--pool-name capos-root \
 		--force
 	$(STAGING_DIR_HOSTPKG)/bin/argosfs import-tree --backend loop \
-		--images $@.disk0,$@.disk1,$@.disk2 \
+		--images $@ \
 		$(call mkfs_target_dir,$(1)) /
 	$(STAGING_DIR_HOSTPKG)/bin/argosfs preflight-root --backend loop \
-		--images $@.disk0,$@.disk1,$@.disk2 --mode rw
-	tar -C $(dir $@) -cf $@.tar $(notdir $@).disk0 $(notdir $@).disk1 $(notdir $@).disk2
-	mv $@.tar $@
+		--images $@ --mode rw
 endef
 
 define Image/Manifest

--- a/package/utils/argosfs/Makefile
+++ b/package/utils/argosfs/Makefile
@@ -1,0 +1,57 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=argosfs
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/fwerkor/argosfs
+PKG_SOURCE_VERSION:=main
+PKG_MIRROR_HASH:=skip
+
+PKG_MAINTAINER:=FWERKOR
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=rust/host fuse3
+HOST_BUILD_DEPENDS:=rust/host
+PKG_BUILD_PARALLEL:=1
+HOST_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/host-build.mk
+include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/rust/rust-package.mk
+include $(TOPDIR)/feeds/packages/lang/rust/rust-host-build.mk
+
+define Package/argosfs
+  SECTION:=utils
+  CATEGORY:=Utilities
+  SUBMENU:=Filesystem
+  TITLE:=ArgosFS root filesystem daemon and tools
+  URL:=https://github.com/fwerkor/argosfs
+  DEPENDS:=$(RUST_ARCH_DEPENDS) +libfuse3 +fuse3-utils +kmod-fuse +libpthread
+endef
+
+define Package/argosfs/description
+ ArgosFS userspace filesystem, raw/loop block backend tooling, and CapOS
+ initramfs rootfs integration.
+endef
+
+define Package/argosfs/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/bin/argosfs $(1)/usr/sbin/argosfs
+	$(INSTALL_DIR) $(1)/lib/argosfs
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/capos/initramfs/argosfs-root.sh $(1)/lib/argosfs/argosfs-root.sh
+	$(INSTALL_DIR) $(1)/lib/argosfs/initramfs-hooks
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/capos/initramfs/hooks/argosfs $(1)/lib/argosfs/initramfs-hooks/argosfs
+	$(INSTALL_DIR) $(1)/etc/argosfs
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/capos/mkinitramfs/argosfs.conf $(1)/etc/argosfs/initramfs.conf
+	$(INSTALL_DIR) $(1)/lib/systemd/system
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/capos/systemd/argosfs-root.service $(1)/lib/systemd/system/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/capos/systemd/argosfs-health.service $(1)/lib/systemd/system/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/capos/systemd/argosfs-watchdog.service $(1)/lib/systemd/system/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/capos/systemd/argosfs-recovery.target $(1)/lib/systemd/system/
+endef
+
+$(eval $(call RustBinHostBuild))
+$(eval $(call HostBuild))
+$(eval $(call BuildPackage,argosfs))

--- a/package/utils/argosfs/Makefile
+++ b/package/utils/argosfs/Makefile
@@ -48,6 +48,8 @@ define Package/argosfs/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/capos/initramfs/hooks/argosfs $(1)/lib/argosfs/initramfs-hooks/argosfs
 	$(INSTALL_DIR) $(1)/lib/preinit
 	$(INSTALL_BIN) ./files/05_argosfs_root $(1)/lib/preinit/05_argosfs_root
+	$(INSTALL_BIN) ./files/79_argosfs_skip_mount_root $(1)/lib/preinit/79_argosfs_skip_mount_root
+	$(INSTALL_BIN) ./files/81_argosfs_restore_preinit $(1)/lib/preinit/81_argosfs_restore_preinit
 	$(INSTALL_DIR) $(1)/etc/argosfs
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/capos/mkinitramfs/argosfs.conf $(1)/etc/argosfs/initramfs.conf
 	$(INSTALL_DIR) $(1)/lib/systemd/system

--- a/package/utils/argosfs/Makefile
+++ b/package/utils/argosfs/Makefile
@@ -12,7 +12,7 @@ PKG_MAINTAINER:=FWERKOR
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=rust/host fuse3
+PKG_BUILD_DEPENDS:=rust/host fuse3 argosfs/host
 HOST_BUILD_DEPENDS:=rust/host
 PKG_BUILD_PARALLEL:=1
 HOST_BUILD_PARALLEL:=1
@@ -21,6 +21,9 @@ include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
 include $(TOPDIR)/feeds/packages/lang/rust/rust-package.mk
 include $(TOPDIR)/feeds/packages/lang/rust/rust-host-build.mk
+
+HOST_FUSE3_PKG_CONFIG_LIBDIR:=$(shell env -u PKG_CONFIG_LIBDIR -u PKG_CONFIG_PATH PATH=/usr/local/bin:/usr/bin:/bin pkg-config --variable pc_path pkg-config 2>/dev/null)
+CARGO_HOST_VARS += PKG_CONFIG_LIBDIR=$(STAGING_DIR_HOSTPKG)/lib/pkgconfig:$(STAGING_DIR_HOST)/lib/pkgconfig:$(HOST_FUSE3_PKG_CONFIG_LIBDIR)
 
 define Package/argosfs
   SECTION:=utils
@@ -43,6 +46,8 @@ define Package/argosfs/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/capos/initramfs/argosfs-root.sh $(1)/lib/argosfs/argosfs-root.sh
 	$(INSTALL_DIR) $(1)/lib/argosfs/initramfs-hooks
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/capos/initramfs/hooks/argosfs $(1)/lib/argosfs/initramfs-hooks/argosfs
+	$(INSTALL_DIR) $(1)/lib/preinit
+	$(INSTALL_BIN) ./files/05_argosfs_root $(1)/lib/preinit/05_argosfs_root
 	$(INSTALL_DIR) $(1)/etc/argosfs
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/contrib/capos/mkinitramfs/argosfs.conf $(1)/etc/argosfs/initramfs.conf
 	$(INSTALL_DIR) $(1)/lib/systemd/system

--- a/package/utils/argosfs/files/05_argosfs_root
+++ b/package/utils/argosfs/files/05_argosfs_root
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+argosfs_cmdline_enabled() {
+	for arg in $(cat /proc/cmdline 2>/dev/null); do
+		case "$arg" in
+			argosfs.images=*|argosfs.devices=*) return 0 ;;
+		esac
+	done
+	return 1
+}
+
+argosfs_mount_initramfs_root() {
+	[ "$INITRAMFS" = "1" ] || return 0
+	argosfs_cmdline_enabled || return 0
+
+	if [ ! -x /lib/argosfs/argosfs-root.sh ]; then
+		echo "argosfs: /lib/argosfs/argosfs-root.sh is missing" >/dev/console
+		exec sh
+	fi
+
+	exec /lib/argosfs/argosfs-root.sh
+	echo "argosfs: root handoff failed" >/dev/console
+	exec sh
+}
+
+boot_hook_add initramfs argosfs_mount_initramfs_root

--- a/package/utils/argosfs/files/05_argosfs_root
+++ b/package/utils/argosfs/files/05_argosfs_root
@@ -4,14 +4,22 @@ argosfs_cmdline_enabled() {
 	for arg in $(cat /proc/cmdline 2>/dev/null); do
 		case "$arg" in
 			argosfs.images=*|argosfs.devices=*) return 0 ;;
+			argosfs.autoscan=1) return 0 ;;
 		esac
 	done
 	return 1
 }
 
+argosfs_root_enabled() {
+	argosfs_cmdline_enabled && return 0
+	[ -r /etc/argosfs/initramfs.conf ] || return 1
+	. /etc/argosfs/initramfs.conf
+	[ "${ARGOSFS_AUTOSCAN:-0}" = "1" ]
+}
+
 argosfs_mount_initramfs_root() {
 	[ "$INITRAMFS" = "1" ] || return 0
-	argosfs_cmdline_enabled || return 0
+	argosfs_root_enabled || return 0
 
 	if [ ! -x /lib/argosfs/argosfs-root.sh ]; then
 		echo "argosfs: /lib/argosfs/argosfs-root.sh is missing" >/dev/console

--- a/package/utils/argosfs/files/79_argosfs_skip_mount_root
+++ b/package/utils/argosfs/files/79_argosfs_skip_mount_root
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+argosfs_mark_root_active() {
+	[ -e /run/argosfs-root-active ] || return 0
+	export ARGOSFS_ROOT_ACTIVE=1
+	export INITRAMFS=1
+}
+
+argosfs_mark_root_active

--- a/package/utils/argosfs/files/81_argosfs_restore_preinit
+++ b/package/utils/argosfs/files/81_argosfs_restore_preinit
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+argosfs_restore_regular_preinit() {
+	[ "$ARGOSFS_ROOT_ACTIVE" = "1" ] || return 0
+	unset INITRAMFS
+}
+
+argosfs_restore_regular_preinit

--- a/scripts/gen_image_generic.sh
+++ b/scripts/gen_image_generic.sh
@@ -15,7 +15,7 @@ ROOTFSIMAGE="$5"
 ROOTFSPARTTYPE=${ROOTFSPARTTYPE:-83}
 ALIGN="$6"
 
-rm -f "$OUTPUT"
+rm -f "$OUTPUT" "$OUTPUT.kernel"
 
 head=16
 sect=63

--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -26,6 +26,10 @@ ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 ROOTPART:=$(if $(ROOTPART),$(ROOTPART),PARTUUID=$(IMG_PART_SIGNATURE)-02)
 GPT_ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 GPT_ROOTPART:=$(if $(GPT_ROOTPART),$(GPT_ROOTPART),PARTUUID=$(shell echo $(IMG_PART_DISKGUID) | sed 's/00$$/02/'))
+argosfs_part_path = $(patsubst PARTUUID=%,/dev/disk/by-partuuid/%,$(1))
+ROOTPART_BOOTARG:=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),argosfs.images=$(call argosfs_part_path,$(ROOTPART)) rootwait,root=$(ROOTPART) rootwait)
+GPT_ROOTPART_BOOTARG:=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),argosfs.images=$(call argosfs_part_path,$(GPT_ROOTPART)) rootwait,root=$(GPT_ROOTPART) rootwait)
+COMBINED_KERNEL_NAME=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),$(KERNEL_NAME)-initramfs,$(KERNEL_NAME))
 
 GRUB_TIMEOUT:=$(call qstrip,$(CONFIG_GRUB_TIMEOUT))
 GRUB_TITLE:=$(call qstrip,$(CONFIG_GRUB_TITLE))
@@ -33,8 +37,8 @@ GRUB_TITLE:=$(call qstrip,$(CONFIG_GRUB_TITLE))
 BOOTOPTS:=$(call qstrip,$(CONFIG_GRUB_BOOTOPTS))
 
 define Build/combined
-  $(INSTALL_DIR) $@.boot/
-	$(CP) $(KDIR)/$(KERNEL_NAME) $@.boot/efi/openwrt/
+	$(INSTALL_DIR) $@.boot/
+	$(CP) $(KDIR)/$(COMBINED_KERNEL_NAME) $@.boot/efi/openwrt/$(KERNEL_NAME)
 	-$(CP) $(STAGING_DIR_ROOT)/boot/. $@.boot/boot/
 	$(if $(filter $(1),efi),
 		$(INSTALL_DIR) $@.boot/efi/boot
@@ -55,8 +59,8 @@ define Build/grub-config
 	sed \
 		-e 's#@SERIAL_CONFIG@#$(strip $(GRUB_SERIAL_CONFIG))#g' \
 		-e 's#@TERMINAL_CONFIG@#$(strip $(GRUB_TERMINAL_CONFIG))#g' \
-		-e 's#@ROOTPART@#root=$(ROOTPART) rootwait#g' \
-		-e 's#@GPT_ROOTPART@#root=$(GPT_ROOTPART) rootwait#g' \
+		-e 's#@ROOTPART@#$(ROOTPART_BOOTARG)#g' \
+		-e 's#@GPT_ROOTPART@#$(GPT_ROOTPART_BOOTARG)#g' \
 		-e 's#@CMDLINE@#$(BOOTOPTS) $(GRUB_CONSOLE_CMDLINE)#g' \
 		-e 's#@TIMEOUT@#$(GRUB_TIMEOUT)#g' \
 		-e 's#@TITLE@#$(GRUB_TITLE)#g' \

--- a/target/linux/generic/other-files/init
+++ b/target/linux/generic/other-files/init
@@ -2,6 +2,27 @@
 # Copyright (C) 2006 OpenWrt.org
 export INITRAMFS=1
 
+argosfs_cmdline_enabled() {
+	[ -r /proc/cmdline ] || return 1
+	for arg in $(cat /proc/cmdline); do
+		case "$arg" in
+			argosfs.images=*|argosfs.devices=*) return 0 ;;
+		esac
+	done
+	return 1
+}
+
+mkdir -p /proc
+mount -t proc proc /proc 2>/dev/null || true
+if argosfs_cmdline_enabled; then
+	if [ -x /lib/argosfs/argosfs-root.sh ]; then
+		exec /lib/argosfs/argosfs-root.sh
+	fi
+	echo "argosfs: /lib/argosfs/argosfs-root.sh is missing" >/dev/console
+	exec sh
+fi
+umount /proc 2>/dev/null || true
+
 # switch to tmpfs to allow run daemons in jail on initramfs boot
 DIRS=$(echo *)
 NEW_ROOT=/new_root

--- a/target/linux/generic/other-files/init
+++ b/target/linux/generic/other-files/init
@@ -7,14 +7,22 @@ argosfs_cmdline_enabled() {
 	for arg in $(cat /proc/cmdline); do
 		case "$arg" in
 			argosfs.images=*|argosfs.devices=*) return 0 ;;
+			argosfs.autoscan=1) return 0 ;;
 		esac
 	done
 	return 1
 }
 
+argosfs_root_enabled() {
+	argosfs_cmdline_enabled && return 0
+	[ -r /etc/argosfs/initramfs.conf ] || return 1
+	. /etc/argosfs/initramfs.conf
+	[ "${ARGOSFS_AUTOSCAN:-0}" = "1" ]
+}
+
 mkdir -p /proc
 mount -t proc proc /proc 2>/dev/null || true
-if argosfs_cmdline_enabled; then
+if argosfs_root_enabled; then
 	if [ -x /lib/argosfs/argosfs-root.sh ]; then
 		exec /lib/argosfs/argosfs-root.sh
 	fi

--- a/target/linux/loongarch64/image/Makefile
+++ b/target/linux/loongarch64/image/Makefile
@@ -28,6 +28,10 @@ ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 ROOTPART:=$(if $(ROOTPART),$(ROOTPART),PARTUUID=$(IMG_PART_SIGNATURE)-02)
 GPT_ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 GPT_ROOTPART:=$(if $(GPT_ROOTPART),$(GPT_ROOTPART),PARTUUID=$(shell echo $(IMG_PART_DISKGUID) | sed 's/00$$/02/'))
+argosfs_part_path = $(patsubst PARTUUID=%,/dev/disk/by-partuuid/%,$(1))
+ROOTPART_BOOTARG:=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),argosfs.images=$(call argosfs_part_path,$(ROOTPART)) rootwait,root=$(ROOTPART) rootwait)
+GPT_ROOTPART_BOOTARG:=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),argosfs.images=$(call argosfs_part_path,$(GPT_ROOTPART)) rootwait,root=$(GPT_ROOTPART) rootwait)
+COMBINED_KERNEL_NAME=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),$(KERNEL_NAME)-initramfs,$(KERNEL_NAME))
 
 GRUB_TIMEOUT:=$(call qstrip,$(CONFIG_GRUB_TIMEOUT))
 GRUB_TITLE:=$(call qstrip,$(CONFIG_GRUB_TITLE))
@@ -36,7 +40,7 @@ BOOTOPTS:=$(call qstrip,$(CONFIG_GRUB_BOOTOPTS))
 
 define Build/combined
 	$(INSTALL_DIR) $@.boot/
-	$(CP) $(KDIR)/$(KERNEL_NAME) $@.boot/efi/openwrt/
+	$(CP) $(KDIR)/$(COMBINED_KERNEL_NAME) $@.boot/efi/openwrt/$(KERNEL_NAME)
 	$(INSTALL_DIR) $@.boot/efi/boot
 	$(CP) $(STAGING_DIR_IMAGE)/grub2/bootloongarch64.efi $@.boot/efi/boot/
 	KERNELPARTTYPE=ef FAT_TYPE="32" PADDING="1" SIGNATURE="$(IMG_PART_SIGNATURE)" \
@@ -53,8 +57,8 @@ define Build/grub-config
 	sed \
 		-e 's#@SERIAL_CONFIG@#$(strip $(GRUB_SERIAL_CONFIG))#g' \
 		-e 's#@TERMINAL_CONFIG@#$(strip $(GRUB_TERMINAL_CONFIG))#g' \
-		-e 's#@ROOTPART@#root=$(ROOTPART) rootwait#g' \
-		-e 's#@GPT_ROOTPART@#root=$(GPT_ROOTPART) rootwait#g' \
+		-e 's#@ROOTPART@#$(ROOTPART_BOOTARG)#g' \
+		-e 's#@GPT_ROOTPART@#$(GPT_ROOTPART_BOOTARG)#g' \
 		-e 's#@CMDLINE@#$(BOOTOPTS) $(GRUB_CONSOLE_CMDLINE)#g' \
 		-e 's#@TIMEOUT@#$(GRUB_TIMEOUT)#g' \
 		-e 's#@TITLE@#$(GRUB_TITLE)#g' \

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -31,6 +31,7 @@ GPT_ROOTPART:=$(if $(GPT_ROOTPART),$(GPT_ROOTPART),PARTUUID=$(shell echo $(IMG_P
 argosfs_part_path = $(patsubst PARTUUID=%,/dev/disk/by-partuuid/%,$(1))
 ROOTPART_BOOTARG:=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),argosfs.images=$(call argosfs_part_path,$(ROOTPART)) rootwait,root=$(ROOTPART) rootwait)
 GPT_ROOTPART_BOOTARG:=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),argosfs.images=$(call argosfs_part_path,$(GPT_ROOTPART)) rootwait,root=$(GPT_ROOTPART) rootwait)
+COMBINED_KERNEL_NAME=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),bzImage-initramfs,$(KERNEL_NAME))
 
 GRUB_TIMEOUT:=$(call qstrip,$(CONFIG_GRUB_TIMEOUT))
 GRUB_TITLE:=$(call qstrip,$(CONFIG_GRUB_TITLE))
@@ -38,7 +39,7 @@ GRUB_TITLE:=$(call qstrip,$(CONFIG_GRUB_TITLE))
 BOOTOPTS:=$(call qstrip,$(CONFIG_GRUB_BOOTOPTS))
 
 define Build/combined
-	$(CP) $(KDIR)/$(KERNEL_NAME) $@.boot/boot/vmlinuz
+	$(CP) $(KDIR)/$(COMBINED_KERNEL_NAME) $@.boot/boot/vmlinuz
 	-$(CP) $(STAGING_DIR_ROOT)/boot/. $@.boot/boot/
 	$(CP) $(STAGING_DIR_IMAGE)/grub2/boot.img $@.boot/boot/grub/
 	$(CP) $(STAGING_DIR_IMAGE)/grub2/$(if $(filter $(1),efi),gpt,$(GRUB2_VARIANT))-core.img \

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -28,6 +28,9 @@ ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 ROOTPART:=$(if $(ROOTPART),$(ROOTPART),PARTUUID=$(IMG_PART_SIGNATURE)-02)
 GPT_ROOTPART:=$(call qstrip,$(CONFIG_TARGET_ROOTFS_PARTNAME))
 GPT_ROOTPART:=$(if $(GPT_ROOTPART),$(GPT_ROOTPART),PARTUUID=$(shell echo $(IMG_PART_DISKGUID) | sed 's/00$$/02/'))
+argosfs_part_path = $(patsubst PARTUUID=%,/dev/disk/by-partuuid/%,$(1))
+ROOTPART_BOOTARG:=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),argosfs.images=$(call argosfs_part_path,$(ROOTPART)) rootwait,root=$(ROOTPART) rootwait)
+GPT_ROOTPART_BOOTARG:=$(if $(CONFIG_TARGET_ROOTFS_ARGOSFS),argosfs.images=$(call argosfs_part_path,$(GPT_ROOTPART)) rootwait,root=$(GPT_ROOTPART) rootwait)
 
 GRUB_TIMEOUT:=$(call qstrip,$(CONFIG_GRUB_TIMEOUT))
 GRUB_TITLE:=$(call qstrip,$(CONFIG_GRUB_TITLE))
@@ -58,8 +61,8 @@ define Build/grub-config
 	sed \
 		-e 's#@SERIAL_CONFIG@#$(strip $(GRUB_SERIAL_CONFIG))#g' \
 		-e 's#@TERMINAL_CONFIG@#$(strip $(GRUB_TERMINAL_CONFIG))#g' \
-		-e 's#@ROOTPART@#root=$(ROOTPART) rootwait#g' \
-		-e 's#@GPT_ROOTPART@#root=$(GPT_ROOTPART) rootwait#g' \
+		-e 's#@ROOTPART@#$(ROOTPART_BOOTARG)#g' \
+		-e 's#@GPT_ROOTPART@#$(GPT_ROOTPART_BOOTARG)#g' \
 		-e 's#@CMDLINE@#$(BOOTOPTS) $(GRUB_CONSOLE_CMDLINE)#g' \
 		-e 's#@TIMEOUT@#$(GRUB_TIMEOUT)#g' \
 		-e 's#@TITLE@#$(GRUB_TITLE)#g' \
@@ -150,4 +153,3 @@ endef
 include $(SUBTARGET).mk
 
 $(eval $(call BuildImage))
-


### PR DESCRIPTION
## Summary
- Adds TARGET_ROOTFS_ARGOSFS as the default CapOS root filesystem image type
- Adds an argosfs package sourced from https://github.com/fwerkor/argosfs using the main branch
- Adds Image/mkfs/argosfs integration for loop-backed ArgosFS root pool generation

## Notes
- The ArgosFS package intentionally tracks the argosfs main branch, per integration requirement.
- Runtime rootfs is provided by ArgosFS; /boot or EFI may remain a normal bootloader-readable filesystem.

## Validation
- ArgosFS-side CI now includes scripts/test_capos_build.sh to compile ArgosFS inside a CapOS build tree.
- Local ArgosFS validation before PR: cargo fmt, clippy, cargo test, loop backend smoke, shell syntax checks.