### PR TITLE
[codex] Complete WebDesktop CPK MVP hardening

### DIFF
--- a/.github/workflows/os-sanity.yml
+++ b/.github/workflows/os-sanity.yml
@@ -34,7 +34,7 @@ jobs:
           # 只装 menuconfig/metadata 所需的最小集合（不做编译的话不需要一堆工具链依赖）
           sudo apt-get install -y \
             bash coreutils findutils grep sed gawk make \
-            git perl python3 \
+            git perl python3 g++ nodejs jq \
             file rsync \
             libncurses-dev
 
@@ -56,6 +56,20 @@ jobs:
 
           # 只做可读性检查，不 update/install（不触网）
           ./scripts/feeds list >/dev/null
+
+      - name: CapOS webdesktop and capbox smoke tests
+        shell: bash
+        run: |
+          set -euxo pipefail
+
+          bash -n package/capos/capbox/files/capbox
+          g++ -std=gnu++17 -Ipackage/capos/capos-webpanel/src \
+            -o /tmp/capos-api-smoke package/capos/capos-webpanel/src/api.cpp -lcrypt
+          g++ -std=gnu++17 -Ipackage/capos/capos-webpanel/src \
+            -o /tmp/capos-app-smoke package/capos/capos-webpanel/src/app.cpp -lcrypt
+
+          tests/capbox_logic_tests.sh
+          tests/webpanel_frontend_smoke.sh
 
       - name: Kconfig sanity (defconfig)
         shell: bash

--- a/package/capos/capbox/files/capbox
+++ b/package/capos/capbox/files/capbox
@@ -4,6 +4,7 @@ set -euo pipefail
 
 CAPBOX_STATE_DIR="${CAPBOX_STATE_DIR:-/var/lib/capbox}"
 CAPBOX_RUN_DIR="${CAPBOX_RUN_DIR:-/run/capbox}"
+CAPBOX_HOSTEXEC_TIMEOUT="${CAPBOX_HOSTEXEC_TIMEOUT:-10}"
 
 die() {
     echo "$*" >&2
@@ -11,7 +12,7 @@ die() {
 }
 
 need_cmd() {
-    local dep
+    local dep env_item allow_item
     for dep in "$@"; do
         command -v "$dep" >/dev/null 2>&1 || die "missing dependency: $dep"
     done
@@ -258,6 +259,11 @@ manifest_risks_json() {
         []
         + (if (.network.host // false) then ["host_network"] else [] end)
         + (if ((.network.publish // []) | length) > 0 then ["publish_ports"] else [] end)
+        + (if (((.dependencies.apk // []) | length) > 0) then ["apk_dependencies"] else [] end)
+        + (if (((.dependencies.opkg // []) | length) > 0) then ["legacy_opkg_dependencies"] else [] end)
+        + (if (((.dependencies.capp // []) | length) > 0) then ["app_dependencies"] else [] end)
+        + (if ((.container.environment // []) | length) > 0 then ["environment"] else [] end)
+        + (if ((.container.volumes.from // []) | length) > 0 then ["shared_volumes"] else [] end)
         + (if (.container.privileges.enabled // false) then ["privileged_container"] else [] end)
         + (if ((.container.privileges.capabilities // []) | length) > 0 then ["extra_capabilities"] else [] end)
         + (if ((.container.devices // []) | length) > 0 then ["devices"] else [] end)
@@ -366,6 +372,34 @@ manifest_publish_rules_tsv() {
     ' "$manifest"
 }
 
+manifest_capp_dependencies() {
+    local manifest="$1"
+    jq -r '
+        if (.dependencies | type) == "object" then
+            .dependencies.capp // []
+        else
+            []
+        end
+        | .[]
+        | tostring
+    ' "$manifest"
+}
+
+manifest_package_dependencies() {
+    local manifest="$1"
+    jq -r '
+        if (.dependencies | type) == "object" and (.dependencies | has("apk")) then
+            .dependencies.apk // []
+        elif (.dependencies | type) == "object" and (.dependencies | has("opkg")) then
+            .dependencies.opkg // []
+        else
+            []
+        end
+        | .[]
+        | tostring
+    ' "$manifest"
+}
+
 manifest_environment_items() {
     local manifest="$1"
     jq -r '
@@ -408,6 +442,37 @@ manifest_volume_from_refs() {
     ' "$manifest"
 }
 
+manifest_hostexec_allowlist() {
+    local manifest="$1"
+    jq -r '
+        .host.exec.allow // []
+        | .[]
+        | if type == "string" then
+            .
+          elif type == "object" then
+            (.command // .path // "")
+          else
+            empty
+          end
+    ' "$manifest"
+}
+
+validate_environment_item() {
+    local env_item="$1"
+    local name
+
+    [[ "$env_item" == *=* ]] || die "invalid environment item: $env_item"
+    name="${env_item%%=*}"
+    [[ "$name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || die "invalid environment variable name: $name"
+}
+
+validate_hostexec_allow_item() {
+    local command_path="$1"
+
+    [[ "$command_path" = /* ]] || die "hostexec allowlist entries must be absolute paths: $command_path"
+    [[ "$command_path" =~ ^/[A-Za-z0-9._/@+-]+$ ]] || die "hostexec allowlist entry contains unsupported characters: $command_path"
+}
+
 validate_manifest_for_user() {
     local manifest="$1"
     local user="$2"
@@ -437,27 +502,31 @@ validate_manifest_for_user() {
 
     while IFS= read -r dep; do
         [[ -z "$dep" ]] && continue
+        validate_app_name "$dep"
         app_is_installed "$user" "$dep" || die "missing app dependency: $dep"
-    done < <(jq -r '.dependencies.capp // [] | .[]' "$manifest")
+    done < <(manifest_capp_dependencies "$manifest")
 
     while IFS= read -r dep; do
         [[ -z "$dep" ]] && continue
         command -v apk >/dev/null 2>&1 || die "apk is required to verify package dependencies"
         apk info -e "$dep" >/dev/null 2>&1 || die "missing apk dependency: $dep"
-    done < <(jq -r '
-        if (.dependencies | type) == "object" and (.dependencies | has("apk")) then
-            .dependencies.apk // []
-        else
-            .dependencies.opkg // []
-        end
-        | .[]
-    ' "$manifest")
+    done < <(manifest_package_dependencies "$manifest")
 
     while IFS= read -r dep; do
         [[ -z "$dep" ]] && continue
         validate_app_name "$dep"
         app_is_installed "$user" "$dep" || die "missing shared-volume source app: $dep"
     done < <(manifest_volume_from_refs "$manifest")
+
+    while IFS= read -r env_item; do
+        [[ -z "$env_item" ]] && continue
+        validate_environment_item "$env_item"
+    done < <(manifest_environment_items "$manifest")
+
+    while IFS= read -r allow_item; do
+        [[ -z "$allow_item" ]] && continue
+        validate_hostexec_allow_item "$allow_item"
+    done < <(manifest_hostexec_allowlist "$manifest")
 }
 
 validate_publish_mapping() {
@@ -528,6 +597,17 @@ cpk_summary_json() {
                 devices: ($manifest.container.devices // []),
                 host_exec: ($manifest.host.exec.enabled // false)
             },
+            checks: {
+                dependencies: {
+                    apk: ($manifest.dependencies.apk // []),
+                    opkg_legacy: ($manifest.dependencies.opkg // []),
+                    capp: ($manifest.dependencies.capp // [])
+                },
+                publish: ($manifest.network.publish // []),
+                environment: ($manifest.container.environment // []),
+                volumes_from: ($manifest.container.volumes.from // []),
+                host_exec_allow: ($manifest.host.exec.allow // [])
+            },
             risks: $risks,
             manifest: $manifest
         }
@@ -556,6 +636,11 @@ podman_network_gateway() {
 podman_container_running() {
     local container_name="$1"
     podman inspect -f '{{.State.Running}}' "$container_name" 2>/dev/null | grep -qx 'true'
+}
+
+podman_container_exists() {
+    local container_name="$1"
+    podman inspect "$container_name" >/dev/null 2>&1
 }
 
 podman_container_ip() {
@@ -646,6 +731,7 @@ write_app_hostexec() {
                     end
                 )
                 | map(select(length > 0))
+                | map(select(startswith("/")))
                 | unique
             )
         }
@@ -685,6 +771,26 @@ hostexec_validate_request() {
     [[ -x "$command_path" ]] || die "hostexec command is not executable: $command_path"
     hostexec_is_enabled "$user" "$app" || die "hostexec is not enabled for app: $app"
     hostexec_is_allowed "$user" "$app" "$command_path" || die "hostexec command is not allowed for app: $command_path"
+}
+
+hostexec_timeout_seconds() {
+    if [[ "$CAPBOX_HOSTEXEC_TIMEOUT" =~ ^[0-9]+$ ]] && ((CAPBOX_HOSTEXEC_TIMEOUT >= 1 && CAPBOX_HOSTEXEC_TIMEOUT <= 300)); then
+        printf '%s\n' "$CAPBOX_HOSTEXEC_TIMEOUT"
+    else
+        printf '10\n'
+    fi
+}
+
+run_hostexec_command() {
+    local user="$1"
+    shift
+
+    if command -v timeout >/dev/null 2>&1; then
+        run_as_user "$user" timeout "$(hostexec_timeout_seconds)" "$@"
+        return $?
+    fi
+
+    run_as_user "$user" "$@"
 }
 
 run_as_user() {
@@ -1189,6 +1295,7 @@ remove_portmap() {
     local state_file tmp
 
     app_is_installed "$user" "$app" || die "app is not installed: $app"
+    validate_publish_mapping "$listen" "$target" "$proto" "$user"
     state_file="$(app_portmaps_path "$user" "$app")"
     tmp="$(mktemp)"
     jq \
@@ -1341,14 +1448,37 @@ cmd_app_info() {
     render_app_info "$user" "$app"
 }
 
+ensure_app_container() {
+    local user="$1"
+    local app="$2"
+    local container_name manifest meta image_ref
+
+    need_cmd podman
+    container_name="$(container_name_for_app "$user" "$app")"
+    if podman_container_exists "$container_name"; then
+        return 0
+    fi
+
+    manifest="$(app_manifest_json_path "$user" "$app")"
+    meta="$(app_meta_path "$user" "$app")"
+    image_ref="$(manifest_value "$meta" '.image_ref // ""')"
+    [[ -n "$image_ref" && "$image_ref" != "null" ]] || die "app image reference is missing; reinstall app: $app"
+    create_container_from_manifest "$user" "$manifest" "$image_ref"
+}
+
 cmd_app_start() {
     local user="$1"
     local app="$2"
     local container_name
     require_root
+    need_cmd podman
     app_is_installed "$user" "$app" || die "app is not installed: $app"
     container_name="$(container_name_for_app "$user" "$app")"
-    podman start "$container_name" >/dev/null
+    if podman_container_exists "$container_name"; then
+        podman start "$container_name" >/dev/null
+    else
+        ensure_app_container "$user" "$app"
+    fi
     reconcile_portmaps "$user" "$app"
     render_app_info "$user" "$app"
 }
@@ -1356,11 +1486,13 @@ cmd_app_start() {
 cmd_app_stop() {
     local user="$1"
     local app="$2"
-    local container_name rule
+    local container_name
     require_root
     app_is_installed "$user" "$app" || die "app is not installed: $app"
     container_name="$(container_name_for_app "$user" "$app")"
-    podman stop "$container_name" >/dev/null
+    if command -v podman >/dev/null 2>&1 && podman_container_exists "$container_name"; then
+        podman stop "$container_name" >/dev/null
+    fi
     while IFS=$'\t' read -r proto listen target; do
         [[ -n "$proto" ]] || continue
         stop_portmap_rule "$user" "$app" "$proto" "$listen" "$target"
@@ -1373,11 +1505,32 @@ cmd_app_restart() {
     local app="$2"
     local container_name
     require_root
+    need_cmd podman
     app_is_installed "$user" "$app" || die "app is not installed: $app"
     container_name="$(container_name_for_app "$user" "$app")"
-    podman restart "$container_name" >/dev/null
+    if podman_container_exists "$container_name"; then
+        podman restart "$container_name" >/dev/null
+    else
+        ensure_app_container "$user" "$app"
+    fi
     reconcile_portmaps "$user" "$app"
     render_app_info "$user" "$app"
+}
+
+remove_user_network_if_unused() {
+    local user="$1"
+    local app_dir app_name network_name
+
+    for app_dir in "$(user_apps_dir "$user")"/*; do
+        [[ -d "$app_dir" ]] || continue
+        app_name="$(basename "$app_dir")"
+        app_is_installed "$user" "$app_name" && return 0
+    done
+
+    if command -v podman >/dev/null 2>&1; then
+        network_name="$(network_name_for_user "$user")"
+        podman network rm "$network_name" >/dev/null 2>&1 || true
+    fi
 }
 
 cmd_app_uninstall() {
@@ -1399,7 +1552,37 @@ cmd_app_uninstall() {
     if [[ -f "$(desktop_path "$user")" ]] && [[ "$(cat "$(desktop_path "$user")")" == "$app" ]]; then
         rm -f "$(desktop_path "$user")"
     fi
+    remove_user_network_if_unused "$user"
     print_json --arg message "uninstalled $app" '{ok: true, message: $message}'
+}
+
+cmd_app_logs() {
+    local user="$1"
+    local app="$2"
+    local container_name container_output="" hostexec_output="" hostexec_log
+
+    app_is_installed "$user" "$app" || die "app is not installed: $app"
+    container_name="$(container_name_for_app "$user" "$app")"
+    if command -v podman >/dev/null 2>&1 && podman_container_exists "$container_name"; then
+        container_output="$(podman logs --tail 120 "$container_name" 2>&1 || true)"
+    fi
+    hostexec_log="$(app_state_dir "$user" "$app")/hostexec.log"
+    if [[ -f "$hostexec_log" ]]; then
+        hostexec_output="$(tail -n 120 "$hostexec_log" 2>/dev/null || true)"
+    fi
+    jq -n \
+        --arg app "$app" \
+        --arg container "$container_output" \
+        --arg hostexec "$hostexec_output" '
+        {
+            ok: true,
+            app: $app,
+            logs: {
+                container: $container,
+                hostexec: $hostexec
+            }
+        }
+    '
 }
 
 cmd_portmap_list() {
@@ -1452,8 +1635,12 @@ cmd_desktop_set() {
 cmd_reconcile() {
     local user="$1"
     local app="$2"
+    require_root
     if [[ -n "$app" ]]; then
         app_is_installed "$user" "$app" || die "app is not installed: $app"
+        if command -v podman >/dev/null 2>&1; then
+            ensure_app_container "$user" "$app"
+        fi
         reconcile_portmaps "$user" "$app"
         render_app_info "$user" "$app"
         return 0
@@ -1479,7 +1666,7 @@ cmd_hostexec_run() {
 
     local started ended exit_code
     started="$(current_unix_time)"
-    if run_as_user "$user" "$@"; then
+    if run_hostexec_command "$user" "$@"; then
         exit_code=0
     else
         exit_code=$?
@@ -1502,7 +1689,7 @@ cmd_hostexec_invoke() {
 
     tmp="$(mktemp)"
     started="$(current_unix_time)"
-    if run_as_user "$user" "$@" >"$tmp" 2>&1; then
+    if run_hostexec_command "$user" "$@" >"$tmp" 2>&1; then
         exit_code=0
     else
         exit_code=$?
@@ -1537,6 +1724,7 @@ Usage:
   capbox app stop APP [--user USER]
   capbox app restart APP [--user USER]
   capbox app uninstall APP [--user USER]
+  capbox app logs APP [--user USER]
   capbox portmap list APP [--user USER]
   capbox portmap set APP --listen PORT --target PORT [--proto tcp|udp] [--user USER]
   capbox portmap remove APP --listen PORT --target PORT [--proto tcp|udp] [--user USER]
@@ -1617,6 +1805,7 @@ main() {
                 stop) [[ -n "$app" ]] || die "missing app name"; cmd_app_stop "$user" "$app" ;;
                 restart) [[ -n "$app" ]] || die "missing app name"; cmd_app_restart "$user" "$app" ;;
                 uninstall) [[ -n "$app" ]] || die "missing app name"; cmd_app_uninstall "$user" "$app" ;;
+                logs) [[ -n "$app" ]] || die "missing app name"; cmd_app_logs "$user" "$app" ;;
                 *) die "unknown app action: $action" ;;
             esac
             ;;
@@ -1731,4 +1920,6 @@ main() {
     esac
 }
 
-main "$@"
+if [[ "${CAPBOX_LIB_ONLY:-0}" != "1" ]]; then
+    main "$@"
+fi

--- a/package/capos/capos-webpanel/htdocs/assets/app.js
+++ b/package/capos/capos-webpanel/htdocs/assets/app.js
@@ -1,0 +1,604 @@
+"use strict";
+
+const state = {
+  session: null,
+  apps: [],
+  desktop: null,
+  upload: null,
+  pending: new Set(),
+  portApp: null,
+};
+
+const $ = (id) => document.getElementById(id);
+
+const nodes = {
+  loginView: $("loginView"),
+  loginForm: $("loginForm"),
+  loginBtn: $("loginBtn"),
+  username: $("username"),
+  password: $("password"),
+  appShell: $("appShell"),
+  topbar: document.querySelector(".topbar"),
+  controlDrawer: $("controlDrawer"),
+  appsList: $("appsList"),
+  appsCount: $("appsCount"),
+  appSearch: $("appSearch"),
+  appFilter: $("appFilter"),
+  sessionSummary: $("sessionSummary"),
+  userBadge: $("userBadge"),
+  luciLink: $("luciLink"),
+  inspectionBox: $("inspectionBox"),
+  desktopHint: $("desktopHint"),
+  desktopStatus: $("desktopStatus"),
+  desktopFrame: $("desktopFrame"),
+  toastStack: $("toastStack"),
+  cpkFile: $("cpkFile"),
+  uploadBtn: $("uploadBtn"),
+  installBtn: $("installBtn"),
+  portModal: $("portModal"),
+  portForm: $("portForm"),
+  portModalApp: $("portModalApp"),
+  portListen: $("portListen"),
+  portTarget: $("portTarget"),
+  portProto: $("portProto"),
+  savePortBtn: $("savePortBtn"),
+  confirmModal: $("confirmModal"),
+  confirmTitle: $("confirmTitle"),
+  confirmMessage: $("confirmMessage"),
+  confirmOkBtn: $("confirmOkBtn"),
+};
+
+class ApiError extends Error {
+  constructor(message, status, code) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function h(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function showToast(message, kind = "info") {
+  const toast = document.createElement("div");
+  toast.className = `toast ${kind}`;
+  toast.textContent = message;
+  nodes.toastStack.appendChild(toast);
+  setTimeout(() => toast.remove(), 3800);
+}
+
+function resetSessionUi(message) {
+  state.session = null;
+  state.apps = [];
+  state.desktop = null;
+  state.upload = null;
+  nodes.password.value = "";
+  nodes.controlDrawer.classList.remove("open");
+  nodes.loginView.style.display = "grid";
+  nodes.appShell.classList.remove("ready");
+  nodes.installBtn.disabled = true;
+  nodes.inspectionBox.innerHTML = "<p>等待上传 CPK。</p>";
+  if (message) {
+    showToast(message, "error");
+  }
+}
+
+async function api(path, options = {}) {
+  const res = await fetch(`/cgi-bin/cap/api${path}`, {
+    credentials: "same-origin",
+    ...options,
+  });
+  const text = await res.text();
+  let data = {};
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch (error) {
+    throw new ApiError(text || `HTTP ${res.status}`, res.status, "INVALID_JSON");
+  }
+  if (res.status === 401) {
+    resetSessionUi(data.message || "登录状态已过期，请重新登录。");
+    throw new ApiError(data.message || "unauthenticated", res.status, data.error_code || "UNAUTHENTICATED");
+  }
+  if (!res.ok || data.ok === false) {
+    throw new ApiError(data.message || `HTTP ${res.status}`, res.status, data.error_code || "ERROR");
+  }
+  return data;
+}
+
+function setPending(key, pending) {
+  if (pending) {
+    state.pending.add(key);
+  } else {
+    state.pending.delete(key);
+  }
+  renderApps();
+  nodes.loginBtn.disabled = state.pending.has("login");
+  nodes.uploadBtn.disabled = state.pending.has("upload");
+  nodes.installBtn.disabled = !state.upload || state.pending.has("install");
+  nodes.savePortBtn.disabled = state.pending.has("port");
+}
+
+function isDesktopApp(appName) {
+  return Boolean(state.desktop && state.desktop.app === appName);
+}
+
+function risksForApp(item) {
+  const manifest = item.manifest || {};
+  const container = manifest.container || {};
+  const privileges = container.privileges || {};
+  const network = manifest.network || {};
+  const host = manifest.host || {};
+  const exec = host.exec || {};
+  const risks = [];
+  if (network.host || item.permissions?.host_network) risks.push("host network");
+  if (exec.enabled || item.permissions?.host_exec) risks.push("host.exec");
+  if (privileges.enabled) risks.push("privileged");
+  if ((privileges.capabilities || []).length) risks.push("capabilities");
+  if ((container.devices || []).length) risks.push("devices");
+  if ((container.volumes?.extra || []).length) risks.push("host mounts");
+  if ((network.publish || []).length) risks.push("publish");
+  return risks;
+}
+
+function serviceLabel(item) {
+  const desktop = item.desktop || {};
+  if (!desktop.port) {
+    return "未声明";
+  }
+  return `${desktop.scheme || "http"}://${desktop.target_host || "-"}:${desktop.port}`;
+}
+
+function portmapText(map) {
+  return `${map.proto || "tcp"} ${map.listen}->${map.target_port}`;
+}
+
+function appMatches(item, query, filter) {
+  const app = item.app || {};
+  const running = Boolean(item.runtime?.running);
+  const desktop = isDesktopApp(app.name);
+  const risks = risksForApp(item);
+  if (filter === "running" && !running) return false;
+  if (filter === "stopped" && running) return false;
+  if (filter === "desktop" && !desktop) return false;
+  if (filter === "risk" && risks.length === 0) return false;
+  if (!query) return true;
+  const haystack = [
+    app.name,
+    app.nickname,
+    app.version,
+    app.description,
+    item.runtime?.container_name,
+    item.runtime?.ip,
+    serviceLabel(item),
+    ...(item.portmaps || []).map(portmapText),
+    ...risks,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query);
+}
+
+function emptyState(title, message) {
+  return `<div class="empty-state"><h4>${h(title)}</h4><p>${h(message)}</p></div>`;
+}
+
+function renderApps() {
+  const query = nodes.appSearch.value.trim().toLowerCase();
+  const filter = nodes.appFilter.value;
+  const apps = state.apps.filter((item) => appMatches(item, query, filter));
+  nodes.appsCount.textContent = `${state.apps.length} 个应用`;
+
+  if (!state.apps.length) {
+    nodes.appsList.innerHTML = emptyState("还没有已安装应用", "上传 CPK 后，应用会显示在这里。");
+    return;
+  }
+  if (!apps.length) {
+    nodes.appsList.innerHTML = emptyState("没有匹配的应用", "调整搜索词或过滤条件。");
+    return;
+  }
+
+  nodes.appsList.innerHTML = apps
+    .map((item) => {
+      const app = item.app || {};
+      const runtime = item.runtime || {};
+      const running = Boolean(runtime.running);
+      const desktop = isDesktopApp(app.name);
+      const risks = risksForApp(item);
+      const actionPending = (name) => state.pending.has(`${name}:${app.name}`);
+      const disabled = (name) => (actionPending(name) ? "disabled" : "");
+      const portmaps = item.portmaps || [];
+      return `
+        <article class="app-card ${desktop ? "is-desktop" : ""}">
+          <div class="app-title">
+            <div>
+              <h4>${h(app.nickname || app.name)}</h4>
+              <p>${h(app.description || "这个应用还没有提供描述。")}</p>
+            </div>
+            <span class="chip ${running ? "running" : "stopped"}">${running ? "Running" : "Stopped"}</span>
+          </div>
+          <div class="chips">
+            <span class="chip">Version ${h(app.version || "-")}</span>
+            ${desktop ? '<span class="chip desktop-chip">当前桌面</span>' : ""}
+            ${risks.map((risk) => `<span class="chip risk">${h(risk)}</span>`).join("")}
+          </div>
+          <div class="app-grid">
+            <div class="fact"><strong>容器</strong><span>${h(runtime.container_name || "-")}</span></div>
+            <div class="fact"><strong>IP</strong><span>${h(runtime.ip || "-")}</span></div>
+            <div class="fact"><strong>Service</strong><span>${h(serviceLabel(item))}</span></div>
+            <div class="fact"><strong>Image</strong><span>${h(runtime.image_ref || "-")}</span></div>
+          </div>
+          <div class="port-list">
+            ${
+              portmaps.length
+                ? portmaps
+                    .map(
+                      (map) =>
+                        `<button class="port-pill" type="button" data-action="remove-port" data-app="${h(app.name)}" data-listen="${h(map.listen)}" data-target="${h(map.target_port)}" data-proto="${h(map.proto || "tcp")}">${h(portmapText(map))} x</button>`
+                    )
+                    .join("")
+                : '<span class="chip">无端口映射</span>'
+            }
+          </div>
+          <div class="actions">
+            <button class="secondary" data-action="start" data-app="${h(app.name)}" ${disabled("start")}>启动</button>
+            <button class="secondary" data-action="stop" data-app="${h(app.name)}" ${disabled("stop")}>停止</button>
+            <button class="secondary" data-action="restart" data-app="${h(app.name)}" ${disabled("restart")}>重启</button>
+            <button class="secondary" data-action="reconcile" data-app="${h(app.name)}" ${disabled("reconcile")}>修复状态</button>
+            <button class="secondary" data-action="portmap" data-app="${h(app.name)}">映射端口</button>
+            <button class="secondary" data-action="desktop" data-app="${h(app.name)}" ${desktop ? "disabled" : ""}>设为桌面</button>
+            <button class="danger" data-action="uninstall" data-app="${h(app.name)}" ${disabled("uninstall")}>卸载</button>
+          </div>
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderDesktopStatus() {
+  const appName = state.desktop?.app;
+  nodes.desktopHint.textContent = appName ? `当前桌面应用：${appName}` : "请选择一个已安装应用作为桌面应用。";
+
+  if (!appName) {
+    nodes.desktopStatus.className = "desktop-status visible";
+    nodes.desktopStatus.textContent = "还没有设置桌面应用。打开右侧应用面板，选择一个已安装应用作为桌面。";
+    return;
+  }
+
+  const item = state.apps.find((candidate) => candidate.app?.name === appName);
+  if (!item) {
+    nodes.desktopStatus.className = "desktop-status visible";
+    nodes.desktopStatus.textContent = "当前桌面应用记录指向一个不存在的应用，请重新选择桌面应用。";
+    return;
+  }
+  if (!item.runtime?.running) {
+    nodes.desktopStatus.className = "desktop-status visible";
+    nodes.desktopStatus.textContent = `${item.app?.nickname || appName} 尚未启动，启动后桌面区会自动代理它的 HTTP 服务。`;
+    return;
+  }
+  if (!item.desktop?.port) {
+    nodes.desktopStatus.className = "desktop-status visible";
+    nodes.desktopStatus.textContent = `${item.app?.nickname || appName} 没有声明 network.service.http，无法作为桌面 iframe 代理。`;
+    return;
+  }
+  nodes.desktopStatus.className = "desktop-status";
+  nodes.desktopStatus.textContent = "";
+}
+
+function updateViewportOffsets() {
+  const topbarHeight = nodes.topbar ? nodes.topbar.offsetHeight : 62;
+  document.documentElement.style.setProperty("--workspace-top", `${topbarHeight + 24}px`);
+}
+
+function refreshDesktopFrame() {
+  nodes.desktopFrame.src = `/cgi-bin/cap/app?ts=${Date.now()}`;
+}
+
+async function loadSession() {
+  const data = await api("/session");
+  if (!data.authenticated) {
+    resetSessionUi();
+    return false;
+  }
+  state.session = data.session;
+  nodes.loginView.style.display = "none";
+  nodes.appShell.classList.add("ready");
+  nodes.userBadge.textContent = `${data.session.username}${data.session.is_sudo ? " · sudo" : ""}`;
+  nodes.sessionSummary.textContent = `当前用户：${data.session.username} · ${data.session.is_sudo ? "具备 sudo 权限" : "普通用户权限"}`;
+  nodes.luciLink.style.display = data.session.is_sudo ? "inline-flex" : "none";
+  updateViewportOffsets();
+  return true;
+}
+
+async function loadApps() {
+  const data = await api("/apps");
+  state.apps = data.apps || [];
+  renderApps();
+}
+
+async function loadDesktop() {
+  state.desktop = await api("/desktop");
+}
+
+async function refreshAll() {
+  if (!(await loadSession())) {
+    return;
+  }
+  await Promise.all([loadApps(), loadDesktop()]);
+  renderApps();
+  renderDesktopStatus();
+  refreshDesktopFrame();
+}
+
+function formBody(values) {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
+    body: new URLSearchParams(values),
+  };
+}
+
+function confirmDialog(title, message, danger = false) {
+  nodes.confirmTitle.textContent = title;
+  nodes.confirmMessage.textContent = message;
+  nodes.confirmOkBtn.className = danger ? "danger" : "primary";
+  return new Promise((resolve) => {
+    const handler = () => {
+      nodes.confirmModal.removeEventListener("close", handler);
+      resolve(nodes.confirmModal.returnValue === "ok");
+    };
+    nodes.confirmModal.addEventListener("close", handler);
+    nodes.confirmModal.showModal();
+  });
+}
+
+async function appAction(app, action) {
+  const labels = {
+    start: "启动",
+    stop: "停止",
+    restart: "重启",
+    reconcile: "修复状态",
+    uninstall: "卸载",
+  };
+  const danger = action === "uninstall" || action === "stop";
+  if (["stop", "restart", "uninstall"].includes(action)) {
+    const ok = await confirmDialog(`${labels[action]} ${app}`, `确认${labels[action]}应用 ${app}？`, danger);
+    if (!ok) return;
+  }
+  const key = `${action}:${app}`;
+  if (state.pending.has(key)) return;
+  setPending(key, true);
+  try {
+    const path = action === "reconcile" ? `/apps/${encodeURIComponent(app)}/reconcile` : `/apps/${encodeURIComponent(app)}/${action}`;
+    await api(path, { method: "POST" });
+    showToast(`${labels[action]}完成：${app}`, "success");
+    await refreshAll();
+  } finally {
+    setPending(key, false);
+  }
+}
+
+function openPortModal(app) {
+  state.portApp = app;
+  nodes.portModalApp.textContent = `应用：${app}`;
+  nodes.portListen.value = "";
+  nodes.portTarget.value = "";
+  nodes.portProto.value = "tcp";
+  nodes.portModal.showModal();
+  nodes.portListen.focus();
+}
+
+function validPort(value) {
+  return /^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 65535;
+}
+
+async function savePortMapping() {
+  const app = state.portApp;
+  if (!app) return;
+  const listen = nodes.portListen.value.trim();
+  const target = nodes.portTarget.value.trim();
+  const proto = nodes.portProto.value;
+  if (!validPort(listen) || !validPort(target)) {
+    showToast("端口必须是 1-65535。", "error");
+    return;
+  }
+  setPending("port", true);
+  try {
+    await api(`/apps/${encodeURIComponent(app)}/ports`, formBody({ listen, target, proto }));
+    showToast(`已保存 ${app} 的 ${proto} ${listen}->${target}`, "success");
+    nodes.portModal.close();
+    await refreshAll();
+  } finally {
+    setPending("port", false);
+  }
+}
+
+async function removePortMapping(button) {
+  const app = button.dataset.app;
+  const listen = button.dataset.listen;
+  const target = button.dataset.target;
+  const proto = button.dataset.proto || "tcp";
+  const ok = await confirmDialog("删除端口映射", `删除 ${app} 的 ${proto} ${listen}->${target} 映射？`, true);
+  if (!ok) return;
+  await api(`/apps/${encodeURIComponent(app)}/ports`, formBody({ action: "remove", listen, target, proto }));
+  showToast("端口映射已删除", "success");
+  await refreshAll();
+}
+
+function reviewRiskItems(inspection) {
+  const manifest = inspection.manifest || {};
+  const container = manifest.container || {};
+  const privileges = container.privileges || {};
+  const network = manifest.network || {};
+  const hostExec = manifest.host?.exec || {};
+  const items = [];
+  if (network.host || inspection.permissions?.host_network) items.push("使用 host network，容器与宿主机共享网络命名空间。");
+  if (privileges.enabled || inspection.permissions?.privileged) items.push("请求 privileged 容器权限。");
+  if ((container.devices || inspection.permissions?.devices || []).length) items.push(`请求设备访问：${(container.devices || inspection.permissions?.devices || []).join(", ")}`);
+  if (hostExec.enabled || inspection.permissions?.host_exec) items.push("启用 host.exec，可按 token 调用宿主机白名单命令。");
+  if ((container.volumes?.extra || []).length) items.push(`请求宿主机目录挂载：${container.volumes.extra.join(", ")}`);
+  if ((network.publish || inspection.permissions?.publish || []).length) items.push("安装时会创建宿主机端口映射。");
+  if ((privileges.capabilities || inspection.permissions?.capabilities || []).length) items.push(`额外 capabilities：${(privileges.capabilities || inspection.permissions?.capabilities || []).join(", ")}`);
+  return items;
+}
+
+function renderInspection(inspection) {
+  const app = inspection.app || {};
+  const cpk = inspection.cpk || {};
+  const manifest = inspection.manifest || {};
+  const network = manifest.network || {};
+  const env = manifest.container?.environment || [];
+  const dependencies = manifest.dependencies || {};
+  const risks = reviewRiskItems(inspection);
+  nodes.inspectionBox.innerHTML = `
+    <div>
+      <h4>${h(app.nickname || app.name || "未命名应用")}</h4>
+      <p>${h(app.description || "这个 CPK 没有提供描述。")}</p>
+    </div>
+    <div class="review-grid">
+      <div class="fact"><strong>应用名</strong><span>${h(app.name || "-")}</span></div>
+      <div class="fact"><strong>版本</strong><span>${h(app.version || "-")}</span></div>
+      <div class="fact"><strong>架构</strong><span>${h(cpk.arch || "-")}</span></div>
+      <div class="fact"><strong>镜像</strong><span>${h(cpk.image || "-")}</span></div>
+      <div class="fact"><strong>Service</strong><span>${h(network.service?.http ? `http:${network.service.http}` : network.service?.https ? `https:${network.service.https}` : "未声明")}</span></div>
+      <div class="fact"><strong>Publish</strong><span>${h(JSON.stringify(network.publish || []))}</span></div>
+      <div class="fact"><strong>依赖</strong><span>${h(JSON.stringify(dependencies))}</span></div>
+      <div class="fact"><strong>环境变量</strong><span>${h(JSON.stringify(env))}</span></div>
+    </div>
+    ${
+      risks.length
+        ? `<div class="risk-list">${risks.map((risk) => `<div class="risk-item">${h(risk)}</div>`).join("")}</div>`
+        : '<p>未发现 privileged、devices、host.exec、host network 等高风险能力。</p>'
+    }
+  `;
+}
+
+async function uploadCpk() {
+  const file = nodes.cpkFile.files[0];
+  if (!file) {
+    showToast("请先选择一个 CPK 文件。", "error");
+    return;
+  }
+  setPending("upload", true);
+  try {
+    const data = await api(`/upload?filename=${encodeURIComponent(file.name)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: await file.arrayBuffer(),
+    });
+    state.upload = data.upload;
+    renderInspection(data.inspection || {});
+    showToast("上传完成，预检通过。", "success");
+  } catch (error) {
+    state.upload = null;
+    nodes.inspectionBox.innerHTML = `<div class="risk-item">${h(error.message)}</div>`;
+    throw error;
+  } finally {
+    setPending("upload", false);
+  }
+}
+
+async function installUpload() {
+  if (!state.upload) {
+    showToast("还没有可安装的上传结果。", "error");
+    return;
+  }
+  const ok = await confirmDialog("确认安装 CPK", "安装会创建应用状态、载入镜像，并可能按 manifest 创建容器、端口映射和 hostexec token。确认继续？", true);
+  if (!ok) return;
+  setPending("install", true);
+  try {
+    await api("/install", formBody({ upload_id: state.upload.id }));
+    nodes.inspectionBox.innerHTML = "<p>安装成功，可以在应用库中查看。</p>";
+    nodes.cpkFile.value = "";
+    state.upload = null;
+    showToast("应用已安装。", "success");
+    await refreshAll();
+  } finally {
+    setPending("install", false);
+  }
+}
+
+nodes.loginForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  setPending("login", true);
+  try {
+    await api("/login", formBody({ username: nodes.username.value, password: nodes.password.value }));
+    nodes.password.value = "";
+    showToast("登录成功。", "success");
+    await refreshAll();
+  } catch (error) {
+    showToast(error.message, "error");
+  } finally {
+    setPending("login", false);
+  }
+});
+
+$("logoutBtn").addEventListener("click", async () => {
+  try {
+    await api("/logout", { method: "POST" });
+  } catch (error) {
+    showToast(error.message, "error");
+  } finally {
+    resetSessionUi();
+  }
+});
+
+$("toggleDrawerBtn").addEventListener("click", () => nodes.controlDrawer.classList.toggle("open"));
+$("closeDrawerBtn").addEventListener("click", () => nodes.controlDrawer.classList.remove("open"));
+$("refreshBtn").addEventListener("click", () => refreshAll().catch((error) => showToast(error.message, "error")));
+$("appsRefreshBtn").addEventListener("click", () => refreshAll().catch((error) => showToast(error.message, "error")));
+nodes.appSearch.addEventListener("input", renderApps);
+nodes.appFilter.addEventListener("change", renderApps);
+window.addEventListener("resize", updateViewportOffsets);
+
+nodes.appsList.addEventListener("click", async (event) => {
+  const button = event.target.closest("button[data-action]");
+  if (!button) return;
+  const { action, app } = button.dataset;
+  try {
+    if (action === "remove-port") {
+      await removePortMapping(button);
+      return;
+    }
+    if (action === "portmap") {
+      openPortModal(app);
+      return;
+    }
+    if (action === "desktop") {
+      await api("/desktop", formBody({ app }));
+      showToast(`已将 ${app} 设为桌面应用。`, "success");
+      await refreshAll();
+      return;
+    }
+    await appAction(app, action);
+  } catch (error) {
+    showToast(error.message, "error");
+  }
+});
+
+nodes.portForm.addEventListener("submit", async (event) => {
+  if (event.submitter?.value === "cancel") {
+    return;
+  }
+  event.preventDefault();
+  try {
+    await savePortMapping();
+  } catch (error) {
+    showToast(error.message, "error");
+  }
+});
+
+nodes.uploadBtn.addEventListener("click", () => uploadCpk().catch((error) => showToast(error.message, "error")));
+nodes.installBtn.addEventListener("click", () => installUpload().catch((error) => showToast(error.message, "error")));
+
+refreshAll().catch((error) => {
+  resetSessionUi();
+  showToast(error.message, "error");
+});
+updateViewportOffsets();

--- a/package/capos/capos-webpanel/htdocs/assets/styles.css
+++ b/package/capos/capos-webpanel/htdocs/assets/styles.css
@@ -1,0 +1,596 @@
+:root {
+  color-scheme: light;
+  --bg: #e8ebef;
+  --surface: rgba(255, 255, 255, 0.94);
+  --surface-strong: #ffffff;
+  --ink: #18222c;
+  --muted: #62717f;
+  --line: #d7dde4;
+  --accent: #276a8f;
+  --accent-strong: #164f72;
+  --danger: #b23b36;
+  --warning: #9a6517;
+  --success: #1f7a54;
+  --shadow: 0 16px 38px rgba(19, 31, 43, 0.16);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: "Segoe UI", "PingFang SC", "Noto Sans CJK SC", sans-serif;
+  color: var(--ink);
+  background:
+    linear-gradient(135deg, rgba(39, 106, 143, 0.12), transparent 38%),
+    linear-gradient(180deg, #f6f7f8 0%, var(--bg) 100%);
+}
+
+button,
+.link-button,
+input,
+select {
+  font: inherit;
+}
+
+button,
+.link-button {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.14s ease, opacity 0.14s ease, background 0.14s ease;
+  white-space: nowrap;
+}
+
+button:hover,
+.link-button:hover {
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+  transform: none;
+}
+
+.primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.primary:hover {
+  background: var(--accent-strong);
+}
+
+.secondary {
+  background: #fff;
+  color: var(--ink);
+  border: 1px solid var(--line);
+}
+
+.danger {
+  background: rgba(178, 59, 54, 0.12);
+  color: var(--danger);
+}
+
+.small {
+  padding: 6px 9px;
+  font-size: 12px;
+}
+
+.wide {
+  width: 100%;
+}
+
+.icon-button {
+  width: 34px;
+  height: 34px;
+  padding: 0;
+}
+
+label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+input,
+select {
+  width: 100%;
+  min-width: 0;
+  padding: 10px 11px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--ink);
+}
+
+.login {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 20px;
+}
+
+.login-card {
+  width: min(430px, 100%);
+  border: 1px solid rgba(255, 255, 255, 0.62);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  padding: 24px;
+  display: grid;
+  gap: 14px;
+}
+
+.brand-mark {
+  justify-self: start;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 7px 10px;
+  color: var(--accent);
+  font-weight: 800;
+  background: #fff;
+}
+
+.login-card h1,
+.login-card p,
+.panel h3,
+.panel p,
+.modal h3,
+.modal p,
+.empty-state h4,
+.empty-state p {
+  margin: 0;
+}
+
+.login-card h1 {
+  font-size: 28px;
+}
+
+.login-card p,
+.panel p,
+.modal p,
+.empty-state p {
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.app {
+  display: none;
+  min-height: 100vh;
+}
+
+.app.ready {
+  display: block;
+}
+
+.workspace {
+  position: relative;
+  min-height: 100vh;
+  padding-top: var(--workspace-top, 86px);
+}
+
+.desktop {
+  position: relative;
+  height: calc(100vh - var(--workspace-top, 86px));
+  min-height: 360px;
+  background: #f7f8f8;
+}
+
+.desktop-frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+  background: #f7f8f8;
+}
+
+.desktop-status {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 5;
+  display: none;
+  max-width: min(560px, calc(100% - 24px));
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.93);
+  padding: 10px 12px;
+  box-shadow: 0 12px 26px rgba(19, 31, 43, 0.1);
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.desktop-status.visible {
+  display: block;
+}
+
+.topbar {
+  position: fixed;
+  z-index: 20;
+  top: 12px;
+  left: 12px;
+  right: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px);
+  box-shadow: var(--shadow);
+}
+
+.topbar-main {
+  display: grid;
+  min-width: 0;
+}
+
+.topbar-main strong {
+  font-size: 14px;
+}
+
+.topbar-main span {
+  color: var(--muted);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.pill,
+.chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  font-weight: 700;
+}
+
+.pill {
+  padding: 7px 11px;
+  font-size: 13px;
+  background: rgba(39, 106, 143, 0.12);
+  color: var(--accent);
+}
+
+.control-drawer {
+  position: fixed;
+  top: var(--workspace-top, 86px);
+  right: 12px;
+  bottom: 12px;
+  width: min(520px, calc(100vw - 24px));
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  padding: 14px;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 12px;
+  z-index: 18;
+  transform: translateX(calc(100% + 18px));
+  transition: transform 0.2s ease;
+}
+
+.control-drawer.open {
+  transform: translateX(0);
+}
+
+.drawer-head,
+.panel-head,
+.modal-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.drawer-head h2,
+.drawer-head p {
+  margin: 0;
+}
+
+.drawer-head h2 {
+  font-size: 18px;
+}
+
+.drawer-head p {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.drawer-content {
+  overflow: auto;
+  display: grid;
+  gap: 12px;
+  padding-right: 4px;
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.78);
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.panel h3 {
+  font-size: 15px;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 132px;
+  gap: 8px;
+}
+
+.apps {
+  display: grid;
+  gap: 10px;
+}
+
+.app-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+  padding: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.app-card.is-desktop {
+  border-color: rgba(39, 106, 143, 0.45);
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.app-title {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.app-title h4,
+.app-title p {
+  margin: 0;
+}
+
+.app-title h4 {
+  font-size: 15px;
+}
+
+.app-title p {
+  margin-top: 3px;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.app-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.fact {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 7px 8px;
+  background: #fbfcfd;
+  min-width: 0;
+}
+
+.fact strong {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  margin-bottom: 3px;
+}
+
+.fact span {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+}
+
+.chips,
+.actions,
+.port-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  border: 1px solid var(--line);
+  padding: 4px 8px;
+  background: #fff;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.chip.running {
+  color: var(--success);
+}
+
+.chip.stopped,
+.chip.risk {
+  color: var(--danger);
+}
+
+.chip.warning {
+  color: var(--warning);
+}
+
+.chip.desktop-chip {
+  color: var(--accent);
+  border-color: rgba(39, 106, 143, 0.42);
+  background: rgba(39, 106, 143, 0.08);
+}
+
+.port-pill {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 8px;
+  background: #fff;
+  color: var(--ink);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.actions button {
+  font-size: 12px;
+  padding: 6px 9px;
+}
+
+.upload-box {
+  display: grid;
+  gap: 9px;
+}
+
+.review {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcfd;
+  padding: 10px;
+  display: grid;
+  gap: 9px;
+  max-height: 300px;
+  overflow: auto;
+}
+
+.review h4 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.review p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.review-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.risk-list {
+  display: grid;
+  gap: 6px;
+}
+
+.risk-item {
+  border: 1px solid rgba(178, 59, 54, 0.24);
+  border-radius: 8px;
+  background: rgba(178, 59, 54, 0.06);
+  padding: 8px;
+  color: var(--danger);
+  font-size: 12px;
+}
+
+.empty-state {
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.68);
+  padding: 14px;
+  display: grid;
+  gap: 5px;
+}
+
+.toast-stack {
+  position: fixed;
+  right: 14px;
+  bottom: 14px;
+  z-index: 50;
+  display: grid;
+  gap: 8px;
+  width: min(360px, calc(100vw - 28px));
+}
+
+.toast {
+  padding: 11px 12px;
+  border-radius: 10px;
+  background: rgba(22, 32, 40, 0.94);
+  color: #fff;
+  box-shadow: var(--shadow);
+  font-size: 13px;
+}
+
+.toast.error {
+  background: rgba(178, 59, 54, 0.96);
+}
+
+.toast.success {
+  background: rgba(31, 122, 84, 0.96);
+}
+
+.modal {
+  border: none;
+  padding: 0;
+  background: transparent;
+}
+
+.modal::backdrop {
+  background: rgba(24, 34, 44, 0.36);
+}
+
+.modal-card {
+  width: min(420px, calc(100vw - 28px));
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: var(--shadow);
+  padding: 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+@media (max-width: 760px) {
+  .topbar {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .topbar-main {
+    width: 100%;
+  }
+
+  .topbar-actions {
+    width: 100%;
+  }
+
+  .filters,
+  .app-grid,
+  .review-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/package/capos/capos-webpanel/htdocs/index.html
+++ b/package/capos/capos-webpanel/htdocs/index.html
@@ -4,384 +4,25 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>CapOS WebDesktop</title>
-    <style>
-      :root {
-        --bg: #ebe3d6;
-        --surface: rgba(255, 251, 244, 0.96);
-        --ink: #15202a;
-        --muted: #65727d;
-        --line: #ddd2c1;
-        --accent: #c75531;
-        --danger: #b53b33;
-        --shadow: 0 16px 36px rgba(23, 30, 36, 0.15);
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
-      html,
-      body {
-        margin: 0;
-        min-height: 100%;
-        font-family: "Segoe UI", "PingFang SC", sans-serif;
-        color: var(--ink);
-        background: linear-gradient(180deg, #f3ecdf 0%, var(--bg) 100%);
-      }
-
-      button,
-      .link-button,
-      input {
-        font: inherit;
-      }
-
-      button,
-      .link-button {
-        border: none;
-        border-radius: 999px;
-        padding: 8px 14px;
-        cursor: pointer;
-        text-decoration: none;
-        transition: transform 0.14s ease, opacity 0.14s ease;
-      }
-
-      button:hover,
-      .link-button:hover {
-        transform: translateY(-1px);
-      }
-
-      .primary {
-        background: var(--accent);
-        color: #fff;
-      }
-
-      .secondary {
-        background: #fff;
-        color: var(--ink);
-        border: 1px solid var(--line);
-      }
-
-      .danger {
-        background: rgba(181, 59, 51, 0.12);
-        color: var(--danger);
-      }
-
-      .login {
-        display: grid;
-        place-items: center;
-        min-height: 100vh;
-        padding: 20px;
-      }
-
-      .login-card {
-        width: min(420px, 100%);
-        border: 1px solid rgba(255, 255, 255, 0.5);
-        border-radius: 22px;
-        background: var(--surface);
-        box-shadow: var(--shadow);
-        padding: 24px;
-        display: grid;
-        gap: 14px;
-      }
-
-      .login-card h1,
-      .login-card p {
-        margin: 0;
-      }
-
-      .login-card p {
-        color: var(--muted);
-      }
-
-      input[type="text"],
-      input[type="password"],
-      input[type="file"] {
-        width: 100%;
-        padding: 11px 13px;
-        border-radius: 12px;
-        border: 1px solid var(--line);
-        background: #fff;
-      }
-
-      .app {
-        display: none;
-        min-height: 100vh;
-      }
-
-      .app.ready {
-        display: block;
-      }
-
-      .workspace {
-        position: relative;
-        min-height: 100vh;
-        padding-top: var(--workspace-top, 84px);
-      }
-
-      .desktop {
-        height: calc(100vh - var(--workspace-top, 84px));
-      }
-
-      .desktop-frame {
-        width: 100%;
-        height: 100%;
-        border: none;
-        display: block;
-        background: #f7f6f1;
-      }
-
-      .topbar {
-        position: fixed;
-        z-index: 20;
-        top: 12px;
-        left: 12px;
-        right: 12px;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        gap: 10px;
-        padding: 10px 14px;
-        border-radius: 16px;
-        border: 1px solid var(--line);
-        background: rgba(255, 251, 244, 0.9);
-        backdrop-filter: blur(10px);
-        box-shadow: var(--shadow);
-      }
-
-      .topbar-main {
-        display: grid;
-        min-width: 0;
-      }
-
-      .topbar-main strong {
-        font-size: 14px;
-      }
-
-      .topbar-main span {
-        color: var(--muted);
-        font-size: 12px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .topbar-actions {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
-
-      .pill {
-        display: inline-flex;
-        align-items: center;
-        border-radius: 999px;
-        padding: 7px 12px;
-        font-size: 13px;
-        font-weight: 700;
-        background: rgba(199, 85, 49, 0.12);
-        color: var(--accent);
-      }
-
-      .control-drawer {
-        position: fixed;
-        top: var(--workspace-top, 84px);
-        right: 12px;
-        bottom: 12px;
-        width: min(360px, calc(100vw - 24px));
-        border: 1px solid var(--line);
-        border-radius: 18px;
-        background: var(--surface);
-        box-shadow: var(--shadow);
-        padding: 14px;
-        display: grid;
-        grid-template-rows: auto 1fr;
-        gap: 12px;
-        z-index: 18;
-        transform: translateX(calc(100% + 18px));
-        transition: transform 0.2s ease;
-      }
-
-      .control-drawer.open {
-        transform: translateX(0);
-      }
-
-      .drawer-head {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-      }
-
-      .drawer-head h2,
-      .drawer-head p {
-        margin: 0;
-      }
-
-      .drawer-head h2 {
-        font-size: 16px;
-      }
-
-      .drawer-head p {
-        margin-top: 3px;
-        color: var(--muted);
-        font-size: 12px;
-      }
-
-      .drawer-content {
-        overflow: auto;
-        display: grid;
-        gap: 12px;
-        padding-right: 4px;
-      }
-
-      .panel {
-        border: 1px solid var(--line);
-        border-radius: 14px;
-        background: rgba(255, 255, 255, 0.75);
-        padding: 12px;
-        display: grid;
-        gap: 10px;
-      }
-
-      .panel h3,
-      .panel p {
-        margin: 0;
-      }
-
-      .panel h3 {
-        font-size: 15px;
-      }
-
-      .panel p {
-        font-size: 12px;
-        color: var(--muted);
-      }
-
-      .apps {
-        display: grid;
-        gap: 10px;
-      }
-
-      .app-card {
-        border: 1px solid var(--line);
-        border-radius: 12px;
-        background: #fff;
-        padding: 10px;
-        display: grid;
-        gap: 8px;
-      }
-
-      .app-card h4,
-      .app-card p {
-        margin: 0;
-      }
-
-      .app-card h4 {
-        font-size: 14px;
-      }
-
-      .app-card p {
-        font-size: 12px;
-        color: var(--muted);
-      }
-
-      .app-meta,
-      .actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 6px;
-      }
-
-      .chip {
-        display: inline-flex;
-        border-radius: 999px;
-        border: 1px solid var(--line);
-        padding: 4px 8px;
-        background: #fff;
-        color: var(--muted);
-        font-size: 11px;
-        font-weight: 700;
-      }
-
-      .chip.running {
-        color: #1f7a54;
-      }
-
-      .chip.stopped {
-        color: var(--danger);
-      }
-
-      .chip.portmap {
-        cursor: pointer;
-      }
-
-      .actions button {
-        font-size: 12px;
-        padding: 6px 10px;
-      }
-
-      .upload-box {
-        display: grid;
-        gap: 9px;
-      }
-
-      .inspection {
-        background: #171d22;
-        color: #d7e1e8;
-        border-radius: 10px;
-        padding: 10px;
-        overflow: auto;
-        max-height: 180px;
-        font: 11px/1.4 ui-monospace, monospace;
-      }
-
-      .status {
-        position: fixed;
-        right: 14px;
-        bottom: 14px;
-        max-width: 320px;
-        padding: 12px 14px;
-        border-radius: 12px;
-        background: rgba(22, 32, 40, 0.92);
-        color: #fff;
-        box-shadow: var(--shadow);
-        opacity: 0;
-        transform: translateY(8px);
-        pointer-events: none;
-        transition: opacity 0.2s ease, transform 0.2s ease;
-        z-index: 22;
-      }
-
-      .status.visible {
-        opacity: 1;
-        transform: translateY(0);
-      }
-
-      @media (max-width: 720px) {
-        .topbar {
-          flex-wrap: wrap;
-        }
-
-        .topbar-actions {
-          width: 100%;
-          justify-content: flex-end;
-        }
-
-        .control-drawer {
-          top: 118px;
-        }
-      }
-    </style>
+    <link rel="stylesheet" href="/cap/assets/styles.css" />
   </head>
   <body>
-    <section class="login" id="loginView">
+    <section class="login" id="loginView" aria-labelledby="loginTitle">
       <form class="login-card" id="loginForm">
+        <div class="brand-mark">CapOS</div>
         <div>
-          <h1>CapOS WebDesktop</h1>
-          <p>使用系统 Linux 用户登录，进入你自己的应用桌面。</p>
+          <h1 id="loginTitle">WebDesktop</h1>
+          <p>使用系统 Linux 用户登录，进入你自己的 CPK 应用桌面。</p>
         </div>
-        <input id="username" type="text" autocomplete="username" placeholder="用户名" required />
-        <input id="password" type="password" autocomplete="current-password" placeholder="密码" required />
-        <button class="primary" type="submit">登录</button>
+        <label>
+          <span>用户名</span>
+          <input id="username" type="text" autocomplete="username" required />
+        </label>
+        <label>
+          <span>密码</span>
+          <input id="password" type="password" autocomplete="current-password" required />
+        </label>
+        <button class="primary wide" id="loginBtn" type="submit">登录</button>
       </form>
     </section>
 
@@ -390,35 +31,50 @@
         <header class="topbar">
           <div class="topbar-main">
             <strong>CapOS WebDesktop</strong>
-            <span id="sessionSummary">正在同步你的应用环境…</span>
+            <span id="sessionSummary">正在同步你的应用环境...</span>
             <span id="desktopHint">选择一个已安装应用作为你的桌面应用。</span>
           </div>
           <div class="topbar-actions">
             <span class="pill" id="userBadge">访客</span>
-            <a class="secondary link-button" href="/cgi-bin/luci/" id="luciLink" style="display:none">LuCI</a>
-            <button class="secondary" id="toggleDrawerBtn" type="button">管理</button>
+            <a class="secondary link-button" href="/cgi-bin/luci/" id="luciLink">LuCI</a>
+            <button class="secondary" id="refreshBtn" type="button">刷新</button>
+            <button class="secondary" id="toggleDrawerBtn" type="button">应用</button>
             <button class="danger" id="logoutBtn" type="button">退出</button>
           </div>
         </header>
 
         <main class="desktop">
-          <iframe class="desktop-frame" id="desktopFrame" src="/cgi-bin/cap/app"></iframe>
+          <div class="desktop-status" id="desktopStatus"></div>
+          <iframe class="desktop-frame" id="desktopFrame" src="/cgi-bin/cap/app" title="CapOS desktop app"></iframe>
         </main>
 
         <aside class="control-drawer" id="controlDrawer">
           <div class="drawer-head">
             <div>
-              <h2>控制面板</h2>
-              <p>保持极简，只在需要时展开。</p>
+              <h2>应用</h2>
+              <p>当前登录用户自己的 CPK 应用。</p>
             </div>
             <button class="secondary" id="closeDrawerBtn" type="button">收起</button>
           </div>
 
           <div class="drawer-content">
             <section class="panel">
-              <div>
-                <h3>应用库</h3>
-                <p>仅显示当前登录用户自己的应用。</p>
+              <div class="panel-head">
+                <div>
+                  <h3>应用库</h3>
+                  <p id="appsCount">0 个应用</p>
+                </div>
+                <button class="secondary small" id="appsRefreshBtn" type="button">刷新</button>
+              </div>
+              <div class="filters">
+                <input id="appSearch" type="search" placeholder="搜索应用名、描述、端口" />
+                <select id="appFilter">
+                  <option value="all">全部</option>
+                  <option value="running">运行中</option>
+                  <option value="stopped">已停止</option>
+                  <option value="desktop">当前桌面</option>
+                  <option value="risk">有风险能力</option>
+                </select>
               </div>
               <div class="apps" id="appsList"></div>
             </section>
@@ -426,13 +82,15 @@
             <section class="panel">
               <div>
                 <h3>上传安装 CPK</h3>
-                <p>支持本地上传后预检与安装。</p>
+                <p>上传后先展示人类可读预检，确认后才安装。</p>
               </div>
               <div class="upload-box">
                 <input id="cpkFile" type="file" accept=".cpk,.tar.gz,.tgz" />
                 <button class="primary" id="uploadBtn" type="button">上传并预检</button>
-                <button class="secondary" id="installBtn" type="button" disabled>确认安装</button>
-                <div class="inspection" id="inspectionBox">等待上传 CPK…</div>
+                <div class="review" id="inspectionBox">
+                  <p>等待上传 CPK。</p>
+                </div>
+                <button class="primary" id="installBtn" type="button" disabled>确认安装</button>
               </div>
             </section>
           </div>
@@ -440,319 +98,54 @@
       </div>
     </section>
 
-    <div class="status" id="statusToast"></div>
+    <dialog class="modal" id="portModal">
+      <form method="dialog" class="modal-card" id="portForm">
+        <div class="modal-head">
+          <div>
+            <h3>端口映射</h3>
+            <p id="portModalApp">选择宿主机监听端口和容器目标端口。</p>
+          </div>
+          <button class="secondary icon-button" value="cancel" type="submit" aria-label="关闭">x</button>
+        </div>
+        <label>
+          <span>宿主机监听端口</span>
+          <input id="portListen" name="listen" inputmode="numeric" pattern="[0-9]+" required />
+        </label>
+        <label>
+          <span>容器目标端口</span>
+          <input id="portTarget" name="target" inputmode="numeric" pattern="[0-9]+" required />
+        </label>
+        <label>
+          <span>协议</span>
+          <select id="portProto" name="proto">
+            <option value="tcp">tcp</option>
+            <option value="udp">udp</option>
+          </select>
+        </label>
+        <div class="modal-actions">
+          <button class="secondary" value="cancel" type="submit">取消</button>
+          <button class="primary" id="savePortBtn" value="default" type="submit">保存映射</button>
+        </div>
+      </form>
+    </dialog>
 
-    <script>
-      const state = {
-        session: null,
-        apps: [],
-        desktop: null,
-        upload: null,
-      };
+    <dialog class="modal" id="confirmModal">
+      <form method="dialog" class="modal-card">
+        <div class="modal-head">
+          <div>
+            <h3 id="confirmTitle">确认操作</h3>
+            <p id="confirmMessage">确认继续？</p>
+          </div>
+        </div>
+        <div class="modal-actions">
+          <button class="secondary" value="cancel" type="submit">取消</button>
+          <button class="danger" id="confirmOkBtn" value="ok" type="submit">确认</button>
+        </div>
+      </form>
+    </dialog>
 
-      const $ = (id) => document.getElementById(id);
+    <div class="toast-stack" id="toastStack" aria-live="polite"></div>
 
-      const loginView = $("loginView");
-      const appShell = $("appShell");
-      const topbar = document.querySelector(".topbar");
-      const controlDrawer = $("controlDrawer");
-      const appsList = $("appsList");
-      const sessionSummary = $("sessionSummary");
-      const userBadge = $("userBadge");
-      const luciLink = $("luciLink");
-      const inspectionBox = $("inspectionBox");
-      const desktopHint = $("desktopHint");
-      const desktopFrame = $("desktopFrame");
-      const statusToast = $("statusToast");
-
-      function showStatus(message, kind = "info") {
-        statusToast.textContent = message;
-        statusToast.style.background = kind === "error" ? "rgba(181,59,51,.95)" : "rgba(22,32,40,.92)";
-        statusToast.classList.add("visible");
-        clearTimeout(showStatus.timer);
-        showStatus.timer = setTimeout(() => statusToast.classList.remove("visible"), 2800);
-      }
-
-      async function api(path, options = {}) {
-        const res = await fetch(`/cgi-bin/cap/api${path}`, {
-          credentials: "same-origin",
-          ...options,
-        });
-        const text = await res.text();
-        let data;
-        try {
-          data = JSON.parse(text);
-        } catch (error) {
-          throw new Error(text || `HTTP ${res.status}`);
-        }
-        if (!res.ok || data.ok === false) {
-          throw new Error(data.message || `HTTP ${res.status}`);
-        }
-        return data;
-      }
-
-      function setAuthedUi(authed) {
-        loginView.style.display = authed ? "none" : "grid";
-        appShell.classList.toggle("ready", authed);
-      }
-
-      function updateViewportOffsets() {
-        const topbarHeight = topbar ? topbar.offsetHeight : 60;
-        const workspaceTop = topbarHeight + 24;
-        document.documentElement.style.setProperty("--workspace-top", `${workspaceTop}px`);
-      }
-
-      function refreshDesktopFrame() {
-        desktopFrame.src = `/cgi-bin/cap/app?ts=${Date.now()}`;
-      }
-
-      function renderApps() {
-        if (!state.apps.length) {
-          appsList.innerHTML = `<div class="app-card"><h4>还没有已安装应用</h4><p>上传 CPK 之后将在这里显示。</p></div>`;
-          return;
-        }
-
-        appsList.innerHTML = state.apps
-          .map((item) => {
-            const nickname = item.app.nickname || item.app.name;
-            const running = item.runtime.running;
-            const desktop = state.desktop && state.desktop.app === item.app.name;
-            const risks = [];
-            if (item.permissions.host_network) risks.push("Host Network");
-            if (item.permissions.host_exec) risks.push("Host Exec");
-            const portmaps = (item.portmaps || [])
-              .map(
-                (map) =>
-                  `<button class="chip portmap" type="button" data-action="remove-port" data-app="${item.app.name}" data-listen="${map.listen}" data-target="${map.target_port}" data-proto="${map.proto}">${map.proto} ${map.listen}→${map.target_port}</button>`
-              )
-              .join("");
-            return `
-              <article class="app-card">
-                <div>
-                  <h4>${nickname}</h4>
-                  <p>${item.app.description || "这个应用还没有提供描述。"}</p>
-                </div>
-                <div class="app-meta">
-                  <span class="chip ${running ? "running" : "stopped"}">${running ? "Running" : "Stopped"}</span>
-                  <span class="chip">Version ${item.app.version || "-"}</span>
-                  ${desktop ? '<span class="chip">Desktop</span>' : ""}
-                  ${risks.map((risk) => `<span class="chip">${risk}</span>`).join("")}
-                  ${portmaps}
-                </div>
-                <div class="actions">
-                  <button class="secondary" data-action="start" data-app="${item.app.name}">启动</button>
-                  <button class="secondary" data-action="stop" data-app="${item.app.name}">停止</button>
-                  <button class="secondary" data-action="restart" data-app="${item.app.name}">重启</button>
-                  <button class="secondary" data-action="portmap" data-app="${item.app.name}">映射端口</button>
-                  <button class="secondary" data-action="desktop" data-app="${item.app.name}">设为桌面</button>
-                  <button class="danger" data-action="uninstall" data-app="${item.app.name}">卸载</button>
-                </div>
-              </article>
-            `;
-          })
-          .join("");
-      }
-
-      async function loadSession() {
-        const data = await api("/session");
-        if (!data.authenticated) {
-          state.session = null;
-          setAuthedUi(false);
-          return false;
-        }
-
-        state.session = data.session;
-        userBadge.textContent = `${data.session.username}${data.session.is_sudo ? " · sudo" : ""}`;
-        sessionSummary.textContent = `当前用户：${data.session.username} · ${
-          data.session.is_sudo ? "具备 sudo 权限" : "普通用户权限"
-        }`;
-        luciLink.style.display = data.session.is_sudo ? "inline-flex" : "none";
-        setAuthedUi(true);
-        updateViewportOffsets();
-        return true;
-      }
-
-      async function loadApps() {
-        const data = await api("/apps");
-        state.apps = data.apps || [];
-        renderApps();
-      }
-
-      async function loadDesktop() {
-        const data = await api("/desktop");
-        state.desktop = data;
-        desktopHint.textContent = data.app ? `当前桌面应用：${data.app}` : "请选择一个已安装应用作为桌面应用。";
-        updateViewportOffsets();
-        refreshDesktopFrame();
-      }
-
-      async function refreshAll() {
-        if (!(await loadSession())) {
-          return;
-        }
-        await Promise.all([loadApps(), loadDesktop()]);
-      }
-
-      $("toggleDrawerBtn").addEventListener("click", () => controlDrawer.classList.toggle("open"));
-      $("closeDrawerBtn").addEventListener("click", () => controlDrawer.classList.remove("open"));
-      window.addEventListener("resize", updateViewportOffsets);
-
-      $("loginForm").addEventListener("submit", async (event) => {
-        event.preventDefault();
-        try {
-          await api("/login", {
-            method: "POST",
-            headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
-            body: new URLSearchParams({
-              username: $("username").value,
-              password: $("password").value,
-            }),
-          });
-          $("password").value = "";
-          showStatus("登录成功");
-          await refreshAll();
-        } catch (error) {
-          showStatus(error.message, "error");
-        }
-      });
-
-      $("logoutBtn").addEventListener("click", async () => {
-        try {
-          await api("/logout", { method: "POST" });
-        } finally {
-          state.session = null;
-          state.apps = [];
-          state.desktop = null;
-          state.upload = null;
-          inspectionBox.textContent = "等待上传 CPK…";
-          controlDrawer.classList.remove("open");
-          setAuthedUi(false);
-        }
-      });
-
-      appsList.addEventListener("click", async (event) => {
-        const button = event.target.closest("button[data-action]");
-        if (!button) return;
-        const { action, app } = button.dataset;
-        try {
-          if (action === "remove-port") {
-            if (!window.confirm(`移除 ${app} 的 ${button.dataset.proto} ${button.dataset.listen}->${button.dataset.target} 映射？`)) {
-              return;
-            }
-            await api(`/apps/${encodeURIComponent(app)}/ports`, {
-              method: "POST",
-              headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
-              body: new URLSearchParams({
-                action: "remove",
-                listen: button.dataset.listen,
-                target: button.dataset.target,
-                proto: button.dataset.proto,
-              }),
-            });
-            showStatus(`已移除 ${app} 的端口映射`);
-            await refreshAll();
-            return;
-          }
-
-          if (action === "portmap") {
-            const spec = window.prompt("输入端口映射，格式为 宿主端口:容器端口 或 宿主端口:容器端口/udp", "8080:80");
-            if (!spec) {
-              return;
-            }
-            const matched = spec.match(/^(\d+):(\d+)(?:\/(tcp|udp))?$/i);
-            if (!matched) {
-              showStatus("格式不正确，应为 8080:80 或 5353:53/udp", "error");
-              return;
-            }
-            await api(`/apps/${encodeURIComponent(app)}/ports`, {
-              method: "POST",
-              headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
-              body: new URLSearchParams({
-                listen: matched[1],
-                target: matched[2],
-                proto: matched[3] || "tcp",
-              }),
-            });
-            showStatus(`已更新 ${app} 的端口映射`);
-            await refreshAll();
-            return;
-          }
-
-          if (action === "desktop") {
-            await api("/desktop", {
-              method: "POST",
-              headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
-              body: new URLSearchParams({ app }),
-            });
-            showStatus(`已将 ${app} 设为桌面应用`);
-            await loadDesktop();
-            await loadApps();
-            return;
-          }
-
-          if (action === "uninstall" && !window.confirm(`确定要卸载 ${app} 吗？`)) {
-            return;
-          }
-
-          await api(`/apps/${encodeURIComponent(app)}/${action}`, { method: "POST" });
-          showStatus(`操作成功：${action} ${app}`);
-          await refreshAll();
-        } catch (error) {
-          showStatus(error.message, "error");
-        }
-      });
-
-      $("uploadBtn").addEventListener("click", async () => {
-        const file = $("cpkFile").files[0];
-        if (!file) {
-          showStatus("请先选择一个 CPK 文件", "error");
-          return;
-        }
-        try {
-          const data = await api(`/upload?filename=${encodeURIComponent(file.name)}`, {
-            method: "POST",
-            headers: { "Content-Type": "application/octet-stream" },
-            body: await file.arrayBuffer(),
-          });
-          state.upload = data.upload;
-          $("installBtn").disabled = false;
-          inspectionBox.textContent = JSON.stringify(data.inspection, null, 2);
-          showStatus("上传完成，预检通过");
-        } catch (error) {
-          state.upload = null;
-          $("installBtn").disabled = true;
-          inspectionBox.textContent = error.message;
-          showStatus(error.message, "error");
-        }
-      });
-
-      $("installBtn").addEventListener("click", async () => {
-        if (!state.upload) {
-          showStatus("还没有可安装的上传结果", "error");
-          return;
-        }
-        try {
-          await api("/install", {
-            method: "POST",
-            headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
-            body: new URLSearchParams({ upload_id: state.upload.id }),
-          });
-          inspectionBox.textContent = "安装成功，可以在应用库中查看。";
-          $("installBtn").disabled = true;
-          $("cpkFile").value = "";
-          state.upload = null;
-          showStatus("应用已安装");
-          await refreshAll();
-        } catch (error) {
-          showStatus(error.message, "error");
-        }
-      });
-
-      refreshAll().catch((error) => {
-        setAuthedUi(false);
-        showStatus(error.message, "error");
-      });
-      updateViewportOffsets();
-    </script>
+    <script src="/cap/assets/app.js" defer></script>
   </body>
 </html>

--- a/package/capos/capos-webpanel/src/api.cpp
+++ b/package/capos/capos-webpanel/src/api.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 
-#include <glob.h>
+#include <set>
 
 using namespace capos;
 
@@ -33,6 +33,107 @@ std::string sessionJson(const Session& session) {
         << "\"is_sudo\":" << (session.is_sudo ? "true" : "false")
         << "}";
     return out.str();
+}
+
+bool isValidAppName(const std::string& app) {
+    if (app.empty() || app.size() > 64) {
+        return false;
+    }
+    return std::all_of(app.begin(), app.end(), [](unsigned char ch) {
+        return (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_';
+    });
+}
+
+bool isValidUsername(const std::string& username) {
+    if (username.empty() || username.size() > 64) {
+        return false;
+    }
+    return std::all_of(username.begin(), username.end(), [](unsigned char ch) {
+        return std::isalnum(ch) != 0 || ch == '_' || ch == '-' || ch == '.';
+    });
+}
+
+bool validateAppOrSend(const std::string& app) {
+    if (isValidAppName(app)) {
+        return true;
+    }
+    sendJson(400, jsonError("invalid app name", "INVALID_APP_NAME"));
+    return false;
+}
+
+bool parsePortValue(const std::string& value, std::string& normalized) {
+    if (value.empty() || value.size() > 5) {
+        return false;
+    }
+    if (!std::all_of(value.begin(), value.end(), [](unsigned char ch) { return std::isdigit(ch) != 0; })) {
+        return false;
+    }
+    const auto port = std::strtol(value.c_str(), nullptr, 10);
+    if (port < 1 || port > 65535) {
+        return false;
+    }
+    normalized = std::to_string(port);
+    return true;
+}
+
+bool normalizeProto(const std::string& value, std::string& proto) {
+    proto = value.empty() ? "tcp" : value;
+    std::transform(proto.begin(), proto.end(), proto.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return proto == "tcp" || proto == "udp";
+}
+
+bool isValidUploadId(const std::string& uploadId) {
+    return isHexToken(uploadId, 16, 16);
+}
+
+bool hasSuffix(const std::string& value, const std::string& suffix) {
+    return value.size() >= suffix.size() &&
+           value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+bool isValidUploadFilename(const std::string& filename) {
+    if (filename.empty() || filename.size() > 120 || filename == "." || filename == "..") {
+        return false;
+    }
+    if (filename.find('/') != std::string::npos || filename.find('\\') != std::string::npos) {
+        return false;
+    }
+    if (!std::all_of(filename.begin(), filename.end(), [](unsigned char ch) {
+            return std::isalnum(ch) != 0 || ch == '.' || ch == '_' || ch == '-';
+        })) {
+        return false;
+    }
+    return filename.size() >= 4 &&
+           (hasSuffix(filename, ".cpk") || hasSuffix(filename, ".tgz") || hasSuffix(filename, ".tar.gz"));
+}
+
+bool isAllowedAppAction(const std::string& action) {
+    static const std::set<std::string> allowed = {"start", "stop", "restart", "uninstall"};
+    return allowed.count(action) != 0;
+}
+
+int capboxFailureStatus(const std::string& output, int fallback = 400) {
+    const auto lowered = [&output]() {
+        std::string value = output;
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+        return value;
+    }();
+    if (lowered.find("already installed") != std::string::npos ||
+        lowered.find("already allocated") != std::string::npos ||
+        lowered.find("already in use") != std::string::npos) {
+        return 409;
+    }
+    if (lowered.find("sudo") != std::string::npos ||
+        lowered.find("permission") != std::string::npos ||
+        lowered.find("not enabled") != std::string::npos ||
+        lowered.find("not allowed") != std::string::npos) {
+        return 403;
+    }
+    if (lowered.find("not installed") != std::string::npos ||
+        lowered.find("not found") != std::string::npos) {
+        return 404;
+    }
+    return fallback;
 }
 
 std::optional<Session> requireSession() {
@@ -84,6 +185,10 @@ void handleHostexec() {
     const auto token = trim(getenvOrEmpty("HTTP_X_CAPOS_TOKEN"));
     if (app.empty() || user.empty() || token.empty()) {
         sendJson(400, jsonError("X-CapOS-App, X-CapOS-User and X-CapOS-Token are required", "INVALID_REQUEST"));
+        return;
+    }
+    if (!isValidAppName(app) || !isValidUsername(user) || !isHexToken(token, 32, 128)) {
+        sendJson(400, jsonError("invalid hostexec headers", "INVALID_REQUEST"));
         return;
     }
 
@@ -139,6 +244,7 @@ void handleLogin() {
         sendJson(500, jsonError("failed to persist session"));
         return;
     }
+    cleanupExpiredSessions();
 
     sendJson(
         200,
@@ -167,6 +273,19 @@ void handleSessionInfo() {
     sendJson(200, "{\"ok\":true,\"authenticated\":true,\"session\":" + sessionJson(*session) + "}");
 }
 
+void handleMe(const Session& session) {
+    sendJson(200, "{\"ok\":true,\"session\":" + sessionJson(session) + "}");
+}
+
+void handleSystem(const Session& session) {
+    const auto result = runCapbox({"user", "info", "--user", session.username});
+    if (result.exit_code != 0) {
+        sendJson(500, jsonError(trim(result.output), "SYSTEM_INFO_FAILED"));
+        return;
+    }
+    sendJson(200, "{\"ok\":true,\"service\":\"capos-webpanel\",\"user\":" + trim(result.output) + "}");
+}
+
 void handleAppsList(const Session& session) {
     const auto result = runCapbox({"app", "list", "--user", session.username});
     if (result.exit_code != 0) {
@@ -177,6 +296,9 @@ void handleAppsList(const Session& session) {
 }
 
 void handleAppInfo(const Session& session, const std::string& app) {
+    if (!validateAppOrSend(app)) {
+        return;
+    }
     const auto result = runCapbox({"app", "info", app, "--user", session.username});
     if (result.exit_code != 0) {
         sendJson(404, jsonError(trim(result.output), "APP_NOT_FOUND"));
@@ -190,16 +312,61 @@ void handleAppAction(const Session& session, const std::string& app, const std::
         sendJson(405, jsonError("method not allowed", "METHOD_NOT_ALLOWED"));
         return;
     }
+    if (!validateAppOrSend(app)) {
+        return;
+    }
+    if (!isAllowedAppAction(action)) {
+        sendJson(400, jsonError("unsupported app action", "INVALID_ACTION"));
+        return;
+    }
 
     const auto result = runCapbox({"app", action, app, "--user", session.username});
     if (result.exit_code != 0) {
-        sendJson(400, jsonError(trim(result.output), "APP_ACTION_FAILED"));
+        const auto output = trim(result.output);
+        sendJson(capboxFailureStatus(output), jsonError(output, "APP_ACTION_FAILED"));
+        return;
+    }
+    sendJson(200, trim(result.output));
+}
+
+void handleAppReconcile(const Session& session, const std::string& app) {
+    if (getenvOrEmpty("REQUEST_METHOD") != "POST") {
+        sendJson(405, jsonError("method not allowed", "METHOD_NOT_ALLOWED"));
+        return;
+    }
+    if (!validateAppOrSend(app)) {
+        return;
+    }
+    const auto result = runCapbox({"reconcile", app, "--user", session.username});
+    if (result.exit_code != 0) {
+        const auto output = trim(result.output);
+        sendJson(capboxFailureStatus(output), jsonError(output, "RECONCILE_FAILED"));
+        return;
+    }
+    sendJson(200, trim(result.output));
+}
+
+void handleAppLogs(const Session& session, const std::string& app) {
+    if (getenvOrEmpty("REQUEST_METHOD") != "GET") {
+        sendJson(405, jsonError("method not allowed", "METHOD_NOT_ALLOWED"));
+        return;
+    }
+    if (!validateAppOrSend(app)) {
+        return;
+    }
+    const auto result = runCapbox({"app", "logs", app, "--user", session.username});
+    if (result.exit_code != 0) {
+        const auto output = trim(result.output);
+        sendJson(capboxFailureStatus(output), jsonError(output, "APP_LOGS_FAILED"));
         return;
     }
     sendJson(200, trim(result.output));
 }
 
 void handleAppPorts(const Session& session, const std::string& app) {
+    if (!validateAppOrSend(app)) {
+        return;
+    }
     const auto method = getenvOrEmpty("REQUEST_METHOD");
     if (method == "GET") {
         const auto result = runCapbox({"portmap", "list", app, "--user", session.username});
@@ -220,21 +387,36 @@ void handleAppPorts(const Session& session, const std::string& app) {
     const auto action = form.count("action") ? form.at("action") : "set";
     const auto listenIt = form.find("listen");
     const auto targetIt = form.find("target");
-    const auto proto = form.count("proto") ? form.at("proto") : "tcp";
+    std::string proto;
     if (listenIt == form.end() || targetIt == form.end()) {
         sendJson(400, jsonError("listen and target are required", "INVALID_REQUEST"));
+        return;
+    }
+    std::string listen;
+    std::string target;
+    if (!parsePortValue(listenIt->second, listen) || !parsePortValue(targetIt->second, target)) {
+        sendJson(400, jsonError("ports must be between 1 and 65535", "INVALID_PORT"));
+        return;
+    }
+    if (!normalizeProto(form.count("proto") ? form.at("proto") : "tcp", proto)) {
+        sendJson(400, jsonError("proto must be tcp or udp", "INVALID_PROTO"));
+        return;
+    }
+    if (action != "set" && action != "remove") {
+        sendJson(400, jsonError("unsupported port action", "INVALID_ACTION"));
         return;
     }
 
     ExecResult result;
     if (action == "remove") {
-        result = runCapbox({"portmap", "remove", app, "--listen", listenIt->second, "--target", targetIt->second, "--proto", proto, "--user", session.username});
+        result = runCapbox({"portmap", "remove", app, "--listen", listen, "--target", target, "--proto", proto, "--user", session.username});
     } else {
-        result = runCapbox({"portmap", "set", app, "--listen", listenIt->second, "--target", targetIt->second, "--proto", proto, "--user", session.username});
+        result = runCapbox({"portmap", "set", app, "--listen", listen, "--target", target, "--proto", proto, "--user", session.username});
     }
 
     if (result.exit_code != 0) {
-        sendJson(400, jsonError(trim(result.output), "PORTMAP_UPDATE_FAILED"));
+        const auto output = trim(result.output);
+        sendJson(capboxFailureStatus(output), jsonError(output, "PORTMAP_UPDATE_FAILED"));
         return;
     }
     sendJson(200, "{\"ok\":true,\"portmaps\":" + trim(result.output) + "}");
@@ -261,6 +443,9 @@ void handleDesktopSet(const Session& session) {
         sendJson(400, jsonError("app is required", "INVALID_REQUEST"));
         return;
     }
+    if (!validateAppOrSend(appIt->second)) {
+        return;
+    }
 
     const auto result = runCapbox({"desktop", "set", appIt->second, "--user", session.username});
     if (result.exit_code != 0) {
@@ -279,6 +464,13 @@ void handleUpload(const Session& session, const std::map<std::string, std::strin
     std::string filename = "upload.cpk";
     if (const auto it = query.find("filename"); it != query.end() && !it->second.empty()) {
         filename = sanitizeUploadFilename(it->second);
+        if (filename != it->second || !isValidUploadFilename(filename)) {
+            sendJson(400, jsonError("upload filename may only contain letters, digits, dot, dash and underscore and must end with .cpk, .tgz or .tar.gz", "INVALID_UPLOAD_FILENAME"));
+            return;
+        }
+    } else if (!isValidUploadFilename(filename)) {
+        sendJson(400, jsonError("invalid upload filename", "INVALID_UPLOAD_FILENAME"));
+        return;
     }
 
     const auto uploadId = randomHex(8);
@@ -298,7 +490,8 @@ void handleUpload(const Session& session, const std::map<std::string, std::strin
     if (inspect.exit_code != 0) {
         std::remove(targetPath.c_str());
         std::remove(uploadMetaPath(session.id, uploadId).c_str());
-        sendJson(400, jsonError(trim(inspect.output), "INVALID_CPK"));
+        const auto output = trim(inspect.output);
+        sendJson(capboxFailureStatus(output), jsonError(output, "INVALID_CPK"));
         return;
     }
 
@@ -322,7 +515,7 @@ void handleInstall(const Session& session) {
 
     const auto form = parseKv(readRequestBody());
     const auto uploadIt = form.find("upload_id");
-    if (uploadIt == form.end() || uploadIt->second.empty()) {
+    if (uploadIt == form.end() || !isValidUploadId(uploadIt->second)) {
         sendJson(400, jsonError("upload_id is required", "INVALID_REQUEST"));
         return;
     }
@@ -335,7 +528,8 @@ void handleInstall(const Session& session) {
 
     const auto install = runCapbox({"cpk", "install", *path, "--user", session.username});
     if (install.exit_code != 0) {
-        sendJson(400, jsonError(trim(install.output), "INSTALL_FAILED"));
+        const auto output = trim(install.output);
+        sendJson(capboxFailureStatus(output), jsonError(output, "INSTALL_FAILED"));
         return;
     }
 
@@ -347,6 +541,8 @@ void handleInstall(const Session& session) {
 }  // namespace
 
 int main() {
+    cleanupExpiredSessions();
+
     const auto path = effectivePathInfo();
     const auto segments = splitPath(path);
     const auto query = parseKv(getenvOrEmpty("QUERY_STRING"));
@@ -378,6 +574,16 @@ int main() {
         return 0;
     }
 
+    if (segments[0] == "me") {
+        handleMe(*session);
+        return 0;
+    }
+
+    if (segments[0] == "system") {
+        handleSystem(*session);
+        return 0;
+    }
+
     if (segments[0] == "apps") {
         if (segments.size() == 1) {
             handleAppsList(*session);
@@ -390,6 +596,14 @@ int main() {
         if (segments.size() == 3) {
             if (segments[2] == "ports") {
                 handleAppPorts(*session, segments[1]);
+                return 0;
+            }
+            if (segments[2] == "reconcile") {
+                handleAppReconcile(*session, segments[1]);
+                return 0;
+            }
+            if (segments[2] == "logs") {
+                handleAppLogs(*session, segments[1]);
                 return 0;
             }
             handleAppAction(*session, segments[1], segments[2]);

--- a/package/capos/capos-webpanel/src/app.cpp
+++ b/package/capos/capos-webpanel/src/app.cpp
@@ -38,15 +38,20 @@ std::string proxyPrefix() {
     return "/cgi-bin/cap/app";
 }
 
+std::string lowerAscii(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
 std::string requestScheme() {
     auto scheme = getenvOrEmpty("REQUEST_SCHEME");
-    std::transform(scheme.begin(), scheme.end(), scheme.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    scheme = lowerAscii(scheme);
     if (scheme == "http" || scheme == "https") {
         return scheme;
     }
 
     auto https = getenvOrEmpty("HTTPS");
-    std::transform(https.begin(), https.end(), https.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    https = lowerAscii(https);
     if (https == "on" || https == "1" || https == "yes" || https == "true") {
         return "https";
     }
@@ -59,6 +64,37 @@ std::string requestScheme() {
     }
 
     return "http";
+}
+
+bool isWebSocketRequest() {
+    const auto upgrade = lowerAscii(getenvOrEmpty("HTTP_UPGRADE"));
+    return upgrade == "websocket";
+}
+
+std::string stripQueryParam(const std::string& rawQuery, const std::string& excludedKey) {
+    std::stringstream stream(rawQuery);
+    std::string item;
+    std::vector<std::string> kept;
+    while (std::getline(stream, item, '&')) {
+        if (item.empty()) {
+            continue;
+        }
+        const auto eq = item.find('=');
+        const auto key = urlDecode(item.substr(0, eq));
+        if (key == excludedKey) {
+            continue;
+        }
+        kept.push_back(item);
+    }
+
+    std::ostringstream out;
+    for (size_t i = 0; i < kept.size(); ++i) {
+        if (i != 0) {
+            out << '&';
+        }
+        out << kept[i];
+    }
+    return out.str();
 }
 
 std::string filterForwardCookies(const std::string& cookieHeader, const std::string& panelSessionId) {
@@ -135,15 +171,16 @@ std::string htmlShell(const std::string& title, const std::string& body) {
         << "<title>" << htmlEscape(title) << "</title>"
         << "<style>"
         << ":root{color-scheme:light;"
-        << "--bg:#f2f0ea;--panel:#fffaf0;--ink:#192126;--muted:#61717d;--line:#d8d2c5;--accent:#ca4e2f;--accent-soft:#ffe0d2;}"
-        << "html,body{height:100%;margin:0;font-family:'Segoe UI',sans-serif;background:radial-gradient(circle at top,#fff9ef, #ece7dd 72%);color:var(--ink);}body{display:flex;min-height:100%;}"
-        << ".shell{display:flex;flex-direction:column;gap:18px;width:100%;padding:22px;box-sizing:border-box;}.card{background:rgba(255,250,240,.92);border:1px solid var(--line);border-radius:20px;box-shadow:0 16px 40px rgba(45,53,59,.08);}"
-        << ".empty{padding:28px;display:flex;flex-direction:column;gap:10px;}.empty h1{margin:0;font-size:22px;}.empty p{margin:0;color:var(--muted);line-height:1.5;}"
-        << ".meta{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;padding:0 28px 24px;}.meta div{background:#fff;border:1px solid var(--line);border-radius:14px;padding:12px 14px;}"
-        << ".meta strong{display:block;font-size:12px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:6px;}"
-        << ".actions{display:flex;gap:12px;flex-wrap:wrap;padding:0 28px 24px;}.button{display:inline-flex;align-items:center;justify-content:center;border-radius:999px;padding:10px 16px;background:var(--accent);color:#fff;text-decoration:none;font-weight:700;}"
-        << ".hint{padding:0 28px 24px;color:var(--muted);}.badge{display:inline-flex;align-items:center;padding:6px 10px;border-radius:999px;background:var(--accent-soft);color:var(--accent);font-weight:700;font-size:12px;}"
-        << ".json{margin:0 28px 28px;background:#171c21;color:#dce4eb;border-radius:16px;padding:16px;overflow:auto;font:12px/1.5 ui-monospace,monospace;}"
+        << "--bg:#eef1f4;--panel:#fff;--ink:#18222c;--muted:#62717f;--line:#d7dde4;--accent:#276a8f;--danger:#b23b36;--soft:#edf5f8;}"
+        << "html,body{height:100%;margin:0;font-family:'Segoe UI',sans-serif;background:linear-gradient(180deg,#f8fafb,#e8edf1);color:var(--ink);}body{display:flex;min-height:100%;}"
+        << ".shell{display:flex;flex-direction:column;gap:14px;width:100%;padding:18px;box-sizing:border-box;}.card{background:rgba(255,255,255,.94);border:1px solid var(--line);border-radius:12px;box-shadow:0 16px 36px rgba(19,31,43,.12);}"
+        << ".empty{padding:22px;display:flex;flex-direction:column;gap:10px;}.empty h1{margin:0;font-size:22px;}.empty p{margin:0;color:var(--muted);line-height:1.5;}"
+        << ".meta{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px;padding:0 22px 20px;}.meta div{background:#fbfcfd;border:1px solid var(--line);border-radius:8px;padding:10px 12px;overflow-wrap:anywhere;}"
+        << ".meta strong{display:block;font-size:11px;text-transform:uppercase;color:var(--muted);margin-bottom:5px;}"
+        << ".actions{display:flex;gap:8px;flex-wrap:wrap;padding:0 22px 20px;}.button{display:inline-flex;align-items:center;justify-content:center;border-radius:8px;padding:9px 12px;background:var(--accent);color:#fff;text-decoration:none;font-weight:700;border:0;cursor:pointer;font:inherit;}"
+        << ".button.secondary{background:#fff;color:var(--ink);border:1px solid var(--line);}.button.danger{background:rgba(178,59,54,.1);color:var(--danger);}"
+        << ".hint{padding:0 22px 20px;color:var(--muted);}.badge{display:inline-flex;align-items:center;padding:5px 9px;border-radius:999px;background:var(--soft);color:var(--accent);font-weight:700;font-size:12px;}"
+        << ".json{margin:0 22px 22px;background:#18222c;color:#dce4eb;border-radius:8px;padding:14px;overflow:auto;font:12px/1.5 ui-monospace,monospace;}"
         << "</style></head><body><main class=\"shell\">" << body << "</main></body></html>";
     return out.str();
 }
@@ -186,14 +223,40 @@ std::string replaceAll(std::string text, const std::string& from, const std::str
 
 std::string rewriteHtmlBody(std::string body) {
     const auto prefix = proxyPrefix();
-    body = replaceAll(body, "href=\"/", "href=\"" + prefix + "/");
-    body = replaceAll(body, "src=\"/", "src=\"" + prefix + "/");
-    body = replaceAll(body, "action=\"/", "action=\"" + prefix + "/");
-    body = replaceAll(body, "href='/", "href='" + prefix + "/");
-    body = replaceAll(body, "src='/", "src='" + prefix + "/");
-    body = replaceAll(body, "action='/", "action='" + prefix + "/");
+    const std::vector<std::string> markers = {
+        "href=\"/", "src=\"/", "action=\"/", "poster=\"/",
+        "href='/", "src='/", "action='/", "poster='/",
+        "HREF=\"/", "SRC=\"/", "ACTION=\"/", "POSTER=\"/",
+        "HREF='/", "SRC='/", "ACTION='/", "POSTER='/",
+    };
+    for (const auto& marker : markers) {
+        size_t pos = 0;
+        while ((pos = body.find(marker, pos)) != std::string::npos) {
+            const auto slash = pos + marker.size() - 1;
+            if (slash + 1 < body.size() && body[slash + 1] == '/') {
+                pos = slash + 2;
+                continue;
+            }
+            body.replace(slash, 1, prefix + "/");
+            pos = slash + prefix.size() + 1;
+        }
+    }
 
-    const auto headPos = body.find("<head");
+    for (const auto& marker : {"url(/", "url('/", "url(\"/"}) {
+        size_t pos = 0;
+        while ((pos = body.find(marker, pos)) != std::string::npos) {
+            const auto slash = pos + std::strlen(marker) - 1;
+            if (slash + 1 < body.size() && body[slash + 1] == '/') {
+                pos = slash + 2;
+                continue;
+            }
+            body.replace(slash, 1, prefix + "/");
+            pos = slash + prefix.size() + 1;
+        }
+    }
+
+    const auto lowered = lowerAscii(body);
+    const auto headPos = lowered.find("<head");
     if (headPos != std::string::npos) {
         const auto tagEnd = body.find('>', headPos);
         if (tagEnd != std::string::npos) {
@@ -354,6 +417,8 @@ std::optional<UpstreamResponse> fetchHttp(const std::string& host, int port, con
     return response;
 }
 
+bool isHopByHop(const std::string& header);
+
 std::string buildForwardRequest(const std::string& host, int port, const std::string& upstreamPath, const std::string& body,
                                 const std::string& panelSessionId) {
     std::ostringstream request;
@@ -378,7 +443,7 @@ std::string buildForwardRequest(const std::string& host, int port, const std::st
         auto name = entry.substr(5, eq - 5);
         auto value = entry.substr(eq + 1);
         std::replace(name.begin(), name.end(), '_', '-');
-        std::transform(name.begin(), name.end(), name.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+        name = lowerAscii(name);
         if (name == "cookie") {
             value = filterForwardCookies(value, panelSessionId);
             if (value.empty()) {
@@ -386,7 +451,7 @@ std::string buildForwardRequest(const std::string& host, int port, const std::st
             }
         }
         // Keep hop-by-hop headers and the panel-managed host header under proxy control.
-        if (name == "host" || name == "connection" || name == "accept-encoding" || name == "content-length") {
+        if (name == "host" || name == "accept-encoding" || name == "content-length" || isHopByHop(name)) {
             continue;
         }
         std::transform(name.begin(), name.end(), name.begin(), [](unsigned char ch) { return static_cast<char>(ch == '-' ? '-' : std::toupper(ch)); });
@@ -405,12 +470,68 @@ std::string buildForwardRequest(const std::string& host, int port, const std::st
 }
 
 bool isHopByHop(const std::string& header) {
-    const std::string lowered = [&header]() {
-        std::string s = header;
-        std::transform(s.begin(), s.end(), s.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-        return s;
-    }();
-    return lowered == "connection" || lowered == "transfer-encoding" || lowered == "content-length";
+    const auto lowered = lowerAscii(header);
+    return lowered == "connection" ||
+           lowered == "keep-alive" ||
+           lowered == "proxy-authenticate" ||
+           lowered == "proxy-authorization" ||
+           lowered == "proxy-connection" ||
+           lowered == "te" ||
+           lowered == "trailer" ||
+           lowered == "transfer-encoding" ||
+           lowered == "upgrade" ||
+           lowered == "content-length";
+}
+
+std::string rewriteResponseLocation(const std::string& value, const std::string& upstreamHost, int upstreamPort) {
+    if (value.empty()) {
+        return value;
+    }
+    if (value[0] == '/' && (value.size() == 1 || value[1] != '/')) {
+        return proxyPrefix() + value;
+    }
+
+    const auto httpPrefix = "http://" + upstreamHost + ":" + std::to_string(upstreamPort);
+    if (value.rfind(httpPrefix + "/", 0) == 0) {
+        return proxyPrefix() + value.substr(httpPrefix.size());
+    }
+    const auto httpPrefixNoPort = "http://" + upstreamHost;
+    if (value.rfind(httpPrefixNoPort + "/", 0) == 0) {
+        return proxyPrefix() + value.substr(httpPrefixNoPort.size());
+    }
+    return value;
+}
+
+std::string rewriteSetCookiePath(const std::string& value) {
+    std::stringstream stream(value);
+    std::string item;
+    std::vector<std::string> parts;
+    bool hasPath = false;
+    while (std::getline(stream, item, ';')) {
+        auto part = trim(item);
+        if (part.empty()) {
+            continue;
+        }
+        const auto lowered = lowerAscii(part);
+        if (lowered.rfind("path=", 0) == 0) {
+            parts.push_back("Path=" + proxyPrefix());
+            hasPath = true;
+        } else {
+            parts.push_back(part);
+        }
+    }
+    if (!hasPath) {
+        parts.push_back("Path=" + proxyPrefix());
+    }
+
+    std::ostringstream out;
+    for (size_t i = 0; i < parts.size(); ++i) {
+        if (i != 0) {
+            out << "; ";
+        }
+        out << parts[i];
+    }
+    return out.str();
 }
 
 std::string renderStatusPage(const std::string& selectedApp, const std::string& infoJson, const std::string& message) {
@@ -420,6 +541,10 @@ std::string renderStatusPage(const std::string& selectedApp, const std::string& 
     const auto running = findJsonBool(infoJson, "running").value_or(false);
     const auto desktopPort = findJsonInt(infoJson, "port");
     const auto hostNetwork = findJsonBool(infoJson, "host_network").value_or(false);
+    const auto targetHost = findJsonString(infoJson, "target_host").value_or("-");
+    const auto scheme = findJsonString(infoJson, "scheme").value_or("-");
+    const auto target = desktopPort.has_value() ? scheme + "://" + targetHost + ":" + std::to_string(*desktopPort) : std::string("-");
+    const auto appUrl = urlEncode(selectedApp);
 
     std::ostringstream body;
     body << "<section class=\"card empty\">"
@@ -434,6 +559,12 @@ std::string renderStatusPage(const std::string& selectedApp, const std::string& 
          << "<div><strong>版本</strong>" << htmlEscape(version) << "</div>"
          << "<div><strong>桌面端口</strong>" << (desktopPort.has_value() ? std::to_string(*desktopPort) : std::string("-")) << "</div>"
          << "<div><strong>访问方式</strong>" << (hostNetwork ? "Host Network" : "Container Proxy") << "</div>"
+         << "<div><strong>目标</strong>" << htmlEscape(target) << "</div>"
+         << "</div>"
+         << "<div class=\"actions\">"
+         << "<button class=\"button\" onclick=\"fetch('/cgi-bin/cap/api/apps/" << htmlEscape(appUrl) << "/start',{method:'POST',credentials:'same-origin'}).then(function(){location.reload();})\">启动应用</button>"
+         << "<a class=\"button secondary\" href=\"javascript:location.reload()\">刷新</a>"
+         << "<a class=\"button secondary\" target=\"_top\" href=\"/cap/\">返回面板</a>"
          << "</div>"
          << "<pre class=\"json\">" << htmlEscape(infoJson) << "</pre>"
          << "</section>";
@@ -449,7 +580,13 @@ int main() {
         return 0;
     }
 
-    const auto query = parseKv(getenvOrEmpty("QUERY_STRING"));
+    if (isWebSocketRequest()) {
+        sendHtml(501, renderEmpty("暂不支持 WebSocket", "当前桌面代理这一轮只支持 HTTP 请求。WebSocket 转发会在后续版本补齐，当前不会静默失败。"));
+        return 0;
+    }
+
+    const auto rawQuery = getenvOrEmpty("QUERY_STRING");
+    const auto query = parseKv(rawQuery);
     std::string selectedApp;
     if (const auto it = query.find("app"); it != query.end()) {
         selectedApp = it->second;
@@ -500,7 +637,7 @@ int main() {
         path = "/";
     }
 
-    const auto upstreamQuery = joinQuery(query, {"app"});
+    const auto upstreamQuery = stripQueryParam(rawQuery, "app");
     std::string upstreamPath = path;
     if (!upstreamQuery.empty()) {
         upstreamPath += (upstreamPath.find('?') == std::string::npos ? "?" : "&");
@@ -540,19 +677,21 @@ int main() {
         response->body = *decoded;
     }
 
-    if (contentType.find("text/html") != std::string::npos) {
+    if (lowerAscii(contentType).find("text/html") != std::string::npos) {
         response->body = rewriteHtmlBody(response->body);
     }
 
     std::vector<std::pair<std::string, std::string>> outHeaders;
     for (const auto& [name, value] : response->headers) {
-        if (isHopByHop(name)) {
+        std::string lowered = name;
+        lowered = lowerAscii(lowered);
+        if (isHopByHop(lowered) || lowered == "content-type") {
             continue;
         }
-        std::string lowered = name;
-        std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-        if (lowered == "location" && !value.empty() && value[0] == '/') {
-            outHeaders.emplace_back(name, proxyPrefix() + value);
+        if (lowered == "location") {
+            outHeaders.emplace_back(name, rewriteResponseLocation(value, *host, static_cast<int>(*port)));
+        } else if (lowered == "set-cookie") {
+            outHeaders.emplace_back(name, rewriteSetCookiePath(value));
         } else {
             outHeaders.emplace_back(name, value);
         }

--- a/package/capos/capos-webpanel/src/common.hpp
+++ b/package/capos/capos-webpanel/src/common.hpp
@@ -500,6 +500,8 @@ inline std::string reasonPhrase(int status) {
         case 404: return "Not Found";
         case 405: return "Method Not Allowed";
         case 409: return "Conflict";
+        case 501: return "Not Implemented";
+        case 502: return "Bad Gateway";
         case 500: return "Internal Server Error";
         default: return "OK";
     }

--- a/package/capos/capos-webpanel/src/common.hpp
+++ b/package/capos/capos-webpanel/src/common.hpp
@@ -4,10 +4,12 @@
 #include <algorithm>
 #include <array>
 #include <cerrno>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <dirent.h>
 #include <fcntl.h>
 #include <fstream>
 #include <iomanip>
@@ -358,6 +360,19 @@ inline std::string sessionPath(const std::string& sessionId) {
     return std::string(kSessionDir) + "/" + sessionId + ".session";
 }
 
+inline bool isHexToken(const std::string& value, size_t minLength, size_t maxLength) {
+    if (value.size() < minLength || value.size() > maxLength) {
+        return false;
+    }
+    return std::all_of(value.begin(), value.end(), [](unsigned char ch) {
+        return std::isxdigit(ch) != 0;
+    });
+}
+
+inline bool isSafeSessionId(const std::string& sessionId) {
+    return isHexToken(sessionId, 32, 96);
+}
+
 inline std::string sessionCookieHeader(const std::string& value, std::time_t maxAge) {
     std::ostringstream header;
     header << kSessionCookieName << '=' << value
@@ -370,6 +385,9 @@ inline std::string uploadPathFor(const std::string& sessionId, const std::string
 }
 
 inline bool saveSession(const Session& session) {
+    if (!isSafeSessionId(session.id)) {
+        return false;
+    }
     std::ostringstream data;
     data << "id=" << session.id << "\n"
          << "username=" << session.username << "\n"
@@ -381,6 +399,10 @@ inline bool saveSession(const Session& session) {
 }
 
 inline std::optional<Session> loadSessionById(const std::string& sessionId) {
+    if (!isSafeSessionId(sessionId)) {
+        return std::nullopt;
+    }
+
     const auto content = readFile(sessionPath(sessionId));
     if (!content.has_value()) {
         return std::nullopt;
@@ -412,6 +434,44 @@ inline std::optional<Session> loadSessionById(const std::string& sessionId) {
         return std::nullopt;
     }
     return session;
+}
+
+inline void cleanupExpiredSessions() {
+    DIR* dir = ::opendir(kSessionDir);
+    if (dir == nullptr) {
+        return;
+    }
+
+    const auto now = std::time(nullptr);
+    while (dirent* entry = ::readdir(dir)) {
+        const std::string name = entry->d_name;
+        const std::string suffix = ".session";
+        if (name.size() <= suffix.size() || name.substr(name.size() - suffix.size()) != suffix) {
+            continue;
+        }
+        const auto sessionId = name.substr(0, name.size() - suffix.size());
+        if (!isSafeSessionId(sessionId)) {
+            continue;
+        }
+        const auto content = readFile(sessionPath(sessionId));
+        if (!content.has_value()) {
+            continue;
+        }
+        std::stringstream stream(*content);
+        std::string line;
+        std::time_t expiresAt = 0;
+        while (std::getline(stream, line)) {
+            const auto pos = line.find('=');
+            if (pos != std::string::npos && line.substr(0, pos) == "expires_at") {
+                expiresAt = static_cast<std::time_t>(std::strtoll(line.substr(pos + 1).c_str(), nullptr, 10));
+                break;
+            }
+        }
+        if (expiresAt != 0 && expiresAt < now) {
+            std::remove(sessionPath(sessionId).c_str());
+        }
+    }
+    ::closedir(dir);
 }
 
 inline std::optional<Session> currentSession() {

--- a/tests/capbox_logic_tests.sh
+++ b/tests/capbox_logic_tests.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CAPBOX_LIB_ONLY=1
+source "$ROOT_DIR/package/capos/capbox/files/capbox"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+export CAPBOX_STATE_DIR="$TMPDIR/state"
+export CAPBOX_RUN_DIR="$TMPDIR/run"
+export PATH="$TMPDIR/bin:$PATH"
+
+mkdir -p "$TMPDIR/bin"
+cat >"$TMPDIR/bin/apk" <<'APK'
+#!/usr/bin/env sh
+if [ "$1" = "info" ] && [ "$2" = "-e" ] && [ "$3" = "busybox" ]; then
+  exit 0
+fi
+exit 1
+APK
+chmod +x "$TMPDIR/bin/apk"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_ok() {
+    ( "$@" ) || fail "expected success: $*"
+}
+
+assert_fail() {
+    if ( "$@" ) >/dev/null 2>&1; then
+        fail "expected failure: $*"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    [[ "$haystack" == *"$needle"* ]] || fail "expected [$haystack] to contain [$needle]"
+}
+
+current_user="$(id -un)"
+ensure_app_dirs "$current_user" sharedapp
+cat >"$(app_manifest_json_path "$current_user" sharedapp)" <<'JSON'
+{"version":"1.1","app":{"name":"sharedapp","version":"1.0"},"network":{},"container":{}}
+JSON
+cat >"$(app_meta_path "$current_user" sharedapp)" <<JSON
+{"container_name":"$(container_name_for_app "$current_user" sharedapp)","network_name":"$(network_name_for_user "$current_user")","image_ref":"localhost/shared:latest"}
+JSON
+
+valid_manifest="$TMPDIR/valid.json"
+cat >"$valid_manifest" <<'JSON'
+{
+  "version": "1.1",
+  "app": {
+    "name": "demo_app",
+    "version": "2.3.4",
+    "nickname": "Demo",
+    "description": "Demo application"
+  },
+  "dependencies": {
+    "apk": ["busybox"],
+    "opkg": ["legacy-should-not-be-checked"],
+    "capp": ["sharedapp"]
+  },
+  "network": {
+    "publish": [
+      "18080:80",
+      {"listen": 18443, "target": 443, "proto": "tcp"}
+    ],
+    "service": {"http": 80}
+  },
+  "container": {
+    "environment": {
+      "PUID": "1000",
+      "PGID": "1000"
+    },
+    "volumes": {
+      "from": ["sharedapp:/data"]
+    }
+  },
+  "host": {
+    "exec": {
+      "enabled": true,
+      "allow": ["/bin/echo"]
+    }
+  }
+}
+JSON
+
+invalid_env_manifest="$TMPDIR/invalid-env.json"
+cat >"$invalid_env_manifest" <<'JSON'
+{
+  "version": "1.1",
+  "app": {"name": "badenv", "version": "1.0"},
+  "container": {"environment": ["BAD-NAME=value"]}
+}
+JSON
+
+invalid_hostexec_manifest="$TMPDIR/invalid-hostexec.json"
+cat >"$invalid_hostexec_manifest" <<'JSON'
+{
+  "version": "1.1",
+  "app": {"name": "badexec", "version": "1.0"},
+  "host": {"exec": {"enabled": true, "allow": ["echo unsafe"]}}
+}
+JSON
+
+assert_ok validate_app_name "demo_app"
+assert_fail validate_app_name "Demo-App"
+
+publish_rows="$(manifest_publish_rules_tsv "$valid_manifest")"
+assert_contains "$publish_rows" $'18080:80\ttcp\t18080\t80'
+assert_contains "$publish_rows" $'{"listen":18443,"target":443,"proto":"tcp"}\ttcp\t18443\t443'
+
+env_rows="$(manifest_environment_items "$valid_manifest")"
+assert_contains "$env_rows" "PUID=1000"
+assert_contains "$env_rows" "PGID=1000"
+
+risks="$(manifest_risks_json "$valid_manifest")"
+assert_contains "$risks" "apk_dependencies"
+assert_contains "$risks" "app_dependencies"
+assert_contains "$risks" "environment"
+assert_contains "$risks" "shared_volumes"
+assert_contains "$risks" "host_exec"
+
+assert_ok validate_manifest_for_user "$valid_manifest" "$current_user"
+assert_fail validate_manifest_for_user "$invalid_env_manifest" "$current_user"
+assert_fail validate_manifest_for_user "$invalid_hostexec_manifest" "$current_user"
+
+assert_ok validate_publish_mapping 18080 80 tcp "$current_user"
+assert_ok validate_publish_mapping 5353 53 udp "$current_user"
+assert_fail validate_publish_mapping 0 80 tcp "$current_user"
+assert_fail validate_publish_mapping 18080 70000 tcp "$current_user"
+assert_fail validate_publish_mapping 18080 80 sctp "$current_user"
+
+ensure_app_dirs "$current_user" hostapp
+cat >"$(app_manifest_json_path "$current_user" hostapp)" <<'JSON'
+{"version":"1.1","app":{"name":"hostapp","version":"1.0"},"host":{"exec":{"enabled":true,"allow":["/bin/echo","relative"]}}}
+JSON
+cat >"$(app_meta_path "$current_user" hostapp)" <<JSON
+{"container_name":"$(container_name_for_app "$current_user" hostapp)","network_name":"$(network_name_for_user "$current_user")","image_ref":"localhost/host:latest"}
+JSON
+write_app_hostexec "$current_user" hostapp "$(app_manifest_json_path "$current_user" hostapp)"
+allowlist="$(cat "$(app_hostexec_path "$current_user" hostapp)")"
+assert_contains "$allowlist" "/bin/echo"
+[[ "$allowlist" != *"relative"* ]] || fail "relative hostexec command leaked into allowlist"
+assert_ok hostexec_validate_request "$current_user" hostapp /bin/echo
+assert_fail hostexec_validate_request "$current_user" hostapp /bin/sh
+
+CAPBOX_HOSTEXEC_TIMEOUT=15
+[[ "$(hostexec_timeout_seconds)" = "15" ]] || fail "expected explicit hostexec timeout"
+CAPBOX_HOSTEXEC_TIMEOUT=999
+[[ "$(hostexec_timeout_seconds)" = "10" ]] || fail "expected capped hostexec timeout fallback"
+
+echo "capbox logic tests passed"

--- a/tests/webpanel_frontend_smoke.sh
+++ b/tests/webpanel_frontend_smoke.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HTDOCS="$ROOT_DIR/package/capos/capos-webpanel/htdocs"
+INDEX="$HTDOCS/index.html"
+APP_JS="$HTDOCS/assets/app.js"
+STYLES="$HTDOCS/assets/styles.css"
+
+test -f "$INDEX"
+test -f "$APP_JS"
+test -f "$STYLES"
+
+node --check "$APP_JS" >/dev/null
+
+if grep -Eq '<style|<script>[[:space:]]*[^<]' "$INDEX"; then
+    echo "index.html should not contain inline style/script blocks" >&2
+    exit 1
+fi
+
+if grep -RInE 'https?://|cdn|telemetry|window\.prompt|window\.confirm' "$HTDOCS"; then
+    echo "frontend should stay local-only and avoid prompt/confirm" >&2
+    exit 1
+fi
+
+node - "$INDEX" "$APP_JS" <<'NODE'
+const fs = require("fs");
+const [indexPath, appPath] = process.argv.slice(2);
+const index = fs.readFileSync(indexPath, "utf8");
+const app = fs.readFileSync(appPath, "utf8");
+const missing = [];
+for (const match of app.matchAll(/\$\("([^"]+)"\)/g)) {
+  const id = match[1];
+  if (!index.includes(`id="${id}"`)) {
+    missing.push(id);
+  }
+}
+if (missing.length) {
+  console.error(`missing DOM ids referenced by app.js: ${[...new Set(missing)].join(", ")}`);
+  process.exit(1);
+}
+NODE
+
+echo "webpanel frontend smoke passed"


### PR DESCRIPTION
## What changed

- Refined the lightweight WebDesktop frontend without adding a framework: split assets, added session-aware 401 handling, app search/filtering, richer app cards, human-readable CPK review, modal-based port mapping, loading guards, confirmations, and desktop guidance.
- Hardened the JSON CGI API with explicit validation for app names, actions, ports, protocols, upload IDs, upload filenames, hostexec headers, session IDs, and stale session cleanup.
- Strengthened capbox Bash runtime checks around manifest dependencies, publish rules, environment variables, shared volumes, hostexec allowlists, timeout handling, app logs, reconcile recovery, and uninstall cleanup.
- Improved the desktop reverse proxy for query/body forwarding, hop-by-hop header filtering, HTML path rewriting, Location and Set-Cookie handling, and explicit WebSocket/HTTPS unsupported pages.
- Added lightweight smoke tests and wired them into os-sanity CI.

## Validation

- `bash -n package/capos/capbox/files/capbox`
- `g++ -std=gnu++17 -Ipackage/capos/capos-webpanel/src -o /tmp/capos-api-smoke package/capos/capos-webpanel/src/api.cpp -lcrypt`
- `g++ -std=gnu++17 -Ipackage/capos/capos-webpanel/src -o /tmp/capos-app-smoke package/capos/capos-webpanel/src/app.cpp -lcrypt`
- `tests/capbox_logic_tests.sh`
- `tests/webpanel_frontend_smoke.sh`
- `git diff --check origin/main..HEAD`