### PR TITLE
CapOS MVP QEMU fixes for WebDesktop proxy

### DIFF
--- a/.github/workflows/os-sanity.yml
+++ b/.github/workflows/os-sanity.yml
@@ -36,7 +36,7 @@ jobs:
             bash coreutils findutils grep sed gawk make \
             git perl python3 g++ nodejs jq \
             file rsync \
-            libncurses-dev
+            libncurses-dev libssl-dev
 
       - name: Assert vendored feeds exist
         shell: bash
@@ -66,10 +66,11 @@ jobs:
           g++ -std=gnu++17 -Ipackage/capos/capos-webpanel/src \
             -o /tmp/capos-api-smoke package/capos/capos-webpanel/src/api.cpp -lcrypt
           g++ -std=gnu++17 -Ipackage/capos/capos-webpanel/src \
-            -o /tmp/capos-app-smoke package/capos/capos-webpanel/src/app.cpp -lcrypt
+            -o /tmp/capos-app-smoke package/capos/capos-webpanel/src/app.cpp -lcrypt -lssl -lcrypto
 
           tests/capbox_logic_tests.sh
           tests/webpanel_frontend_smoke.sh
+          tests/webpanel_proxy_smoke.sh
 
       - name: Kconfig sanity (defconfig)
         shell: bash

--- a/include/image.mk
+++ b/include/image.mk
@@ -352,6 +352,7 @@ endef
 
 define Image/mkfs/argosfs
 	rm -f $@
+	mkdir -p $(call mkfs_target_dir,$(1))/run
 	$(STAGING_DIR_HOSTPKG)/bin/argosfs mkfs --backend loop \
 		--images $@ \
 		--k 1 --m 0 \

--- a/package/capos/capbox/Makefile
+++ b/package/capos/capbox/Makefile
@@ -26,6 +26,8 @@ endef
 define Package/capbox/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) ./files/capbox $(1)/usr/bin/capbox
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/91-capbox-podman-network $(1)/etc/uci-defaults/91-capbox-podman-network
 endef
 
 $(eval $(call BuildPackage,capbox))

--- a/package/capos/capbox/files/91-capbox-podman-network
+++ b/package/capos/capbox/files/91-capbox-podman-network
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+conf="/etc/containers/containers.conf"
+[ -f "$conf" ] || exit 0
+
+# CapOS uses OpenWrt firewall4/nftables. Netavark's iptables compatibility
+# path is fragile on small images because xtables extensions are split out.
+if grep -q '^[[:space:]]*firewall_driver[[:space:]]*=' "$conf"; then
+	sed -i 's/^[[:space:]]*firewall_driver[[:space:]]*=.*/firewall_driver = "nftables"/' "$conf"
+elif grep -q '^[[:space:]]*#firewall_driver[[:space:]]*=' "$conf"; then
+	sed -i 's/^[[:space:]]*#firewall_driver[[:space:]]*=.*/firewall_driver = "nftables"/' "$conf"
+else
+	sed -i '/^[[:space:]]*network_backend[[:space:]]*=[[:space:]]*"netavark"/a firewall_driver = "nftables"' "$conf"
+fi
+
+exit 0

--- a/package/capos/capbox/files/capbox
+++ b/package/capos/capbox/files/capbox
@@ -573,8 +573,10 @@ cpk_summary_json() {
         --arg arch "$(map_machine_arch)" \
         --arg image "$(basename "$image_path")" \
         --arg icon "$(basename "${icon_path:-}")" \
-        --argfile manifest "$manifest" \
+        --slurpfile manifest_file "$manifest" \
         --argjson risks "$(manifest_risks_json "$manifest")" '
+        ($manifest_file[0]) as $manifest
+        |
         {
             ok: true,
             cpk: {
@@ -690,7 +692,9 @@ write_app_meta() {
         --arg image "$image_ref" \
         --arg icon "$icon_name" \
         --arg installed_at "$installed_at" \
-        --argfile manifest "$manifest" '
+        --slurpfile manifest_file "$manifest" '
+        ($manifest_file[0]) as $manifest
+        |
         {
             owner: $owner,
             owner_uid: ($uid | tonumber),
@@ -826,7 +830,7 @@ append_hostexec_log() {
 render_app_info() {
     local user="$1"
     local app="$2"
-    local manifest meta container_name network_name running ip desktop_port desktop_scheme target_host
+    local manifest meta container_name network_name running ip desktop_port desktop_scheme desktop_https_skip_check target_host
     local portmaps='[]'
 
     app_is_installed "$user" "$app" || die "app is not installed: $app"
@@ -863,6 +867,10 @@ render_app_info() {
             desktop_scheme="https"
         fi
     fi
+    desktop_https_skip_check=false
+    if [[ "$desktop_scheme" == "https" ]]; then
+        desktop_https_skip_check="$(jq -r 'if (.network.service.https_skip_check // true) then "true" else "false" end' "$manifest")"
+    fi
 
     target_host="$ip"
     if manifest_bool "$manifest" '.network.host // false'; then
@@ -871,14 +879,19 @@ render_app_info() {
 
     jq -n \
         --arg user "$user" \
-        --argfile manifest "$manifest" \
-        --argfile meta "$meta" \
+        --slurpfile manifest_file "$manifest" \
+        --slurpfile meta_file "$meta" \
         --argjson running "$running" \
         --arg ip "$ip" \
         --arg target_host "$target_host" \
         --arg desktop_scheme "$desktop_scheme" \
         --arg desktop_port "$desktop_port" \
+        --argjson desktop_https_skip_check "$desktop_https_skip_check" \
         --argjson portmaps "$portmaps" '
+        ($manifest_file[0]) as $manifest
+        |
+        ($meta_file[0]) as $meta
+        |
         {
             ok: true,
             owner: $user,
@@ -898,7 +911,8 @@ render_app_info() {
             desktop: {
                 scheme: (if $desktop_port == "" or $desktop_port == "null" then null else $desktop_scheme end),
                 port: (if $desktop_port == "" or $desktop_port == "null" then null else ($desktop_port | tonumber) end),
-                target_host: (if $target_host == "" then null else $target_host end)
+                target_host: (if $target_host == "" then null else $target_host end),
+                https_skip_check: $desktop_https_skip_check
             },
             permissions: {
                 host_network: ($manifest.network.host // false),
@@ -1166,15 +1180,13 @@ start_portmap_rule() {
     local proto="$3"
     local listen="$4"
     local target="$5"
-    local container_name inspect running container_pid pidfile listen_arg target_arg nsenter_cmd spid
+    local container_name container_ip pidfile listen_arg target_arg spid
 
-    need_cmd podman nsenter socat
+    need_cmd podman socat
     container_name="$(container_name_for_app "$user" "$app")"
-    inspect="$(podman inspect -f '{{.State.Running}} {{.State.Pid}}' "$container_name" 2>/dev/null || true)"
-    [[ -n "$inspect" ]] || return 0
-    read -r running container_pid <<< "$inspect"
-    [[ "$running" == "true" ]] || return 0
-    [[ "$container_pid" =~ ^[0-9]+$ && "$container_pid" != "0" ]] || return 0
+    podman_container_running "$container_name" || return 0
+    container_ip="$(podman_container_ip "$container_name")"
+    [[ -n "$container_ip" ]] || container_ip="127.0.0.1"
 
     pidfile="$(portmap_pid_file "$user" "$app" "$proto" "$listen" "$target")"
     if [[ -f "$pidfile" ]]; then
@@ -1188,16 +1200,15 @@ start_portmap_rule() {
 
     if [[ "$proto" == "tcp" ]]; then
         listen_arg="TCP-LISTEN:${listen},fork,reuseaddr"
-        target_arg="TCP:127.0.0.1:${target}"
+        target_arg="TCP:${container_ip}:${target}"
     else
         listen_arg="UDP-LISTEN:${listen},fork,reuseaddr"
-        target_arg="UDP:127.0.0.1:${target}"
+        target_arg="UDP:${container_ip}:${target}"
     fi
 
-    printf -v nsenter_cmd 'nsenter -t %q -n socat STDIO %q' "$container_pid" "$target_arg"
-    socat "$listen_arg" EXEC:"$nsenter_cmd" >/dev/null 2>&1 &
+    socat "$listen_arg" "$target_arg" >/dev/null 2>&1 &
     spid=$!
-    sleep 0.05
+    sleep 1
     if ! kill -0 "$spid" 2>/dev/null; then
         wait "$spid" 2>/dev/null || true
         echo "failed to start port mapping for $app on port $listen/$proto" >&2
@@ -1348,7 +1359,7 @@ cmd_cpk_inspect() {
     [[ -f "$cpk_file" ]] || die "CPK file not found: $cpk_file"
     need_cmd tar jq yq
     tmpdir="$(mktemp -d)"
-    trap 'rm -rf "$tmpdir"' RETURN
+    trap 'rm -rf "${tmpdir:-}"; trap - RETURN' RETURN
     extract_cpk "$cpk_file" "$tmpdir"
     manifest_yaml="$(find_cpk_manifest "$tmpdir")"
     manifest_json="$tmpdir/manifest.json"
@@ -1366,7 +1377,7 @@ cmd_cpk_validate() {
     [[ -f "$cpk_file" ]] || die "CPK file not found: $cpk_file"
     need_cmd tar jq yq
     tmpdir="$(mktemp -d)"
-    trap 'rm -rf "$tmpdir"' RETURN
+    trap 'rm -rf "${tmpdir:-}"; trap - RETURN' RETURN
     extract_cpk "$cpk_file" "$tmpdir"
     manifest_yaml="$(find_cpk_manifest "$tmpdir")"
     manifest_json="$tmpdir/manifest.json"
@@ -1388,7 +1399,7 @@ cmd_cpk_install() {
     ensure_user_dirs "$user"
 
     tmpdir="$(mktemp -d)"
-    trap 'rm -rf "$tmpdir"' RETURN
+    trap 'rm -rf "${tmpdir:-}"; trap - RETURN' RETURN
     extract_cpk "$cpk_file" "$tmpdir"
     manifest_yaml="$(find_cpk_manifest "$tmpdir")"
     manifest_json="$tmpdir/manifest.json"

--- a/package/capos/capos-webpanel/Makefile
+++ b/package/capos/capos-webpanel/Makefile
@@ -13,7 +13,7 @@ define Package/capos-webpanel
   SECTION:=capos
   CATEGORY:=CapOS
   TITLE:=CapOS Web Panel
-  DEPENDS:=+libstdcpp +luci +uhttpd +capbox
+  DEPENDS:=+libstdcpp +libopenssl +luci +uhttpd +libustream-mbedtls +px5g-mbedtls +capbox
 endef
 
 define Package/capos-webpanel/description
@@ -37,7 +37,7 @@ define Build/Compile
 
 	$(TARGET_CXX) $(TARGET_CXXFLAGS) $(TARGET_CPPFLAGS) -std=gnu++17 -I$(PKG_BUILD_DIR)/src \
 		-o $(PKG_BUILD_DIR)/bin/app $(PKG_BUILD_DIR)/src/app.cpp \
-		$(TARGET_LDFLAGS) -lcrypt
+		$(TARGET_LDFLAGS) -lcrypt -lssl -lcrypto
 endef
 
 define Package/capos-webpanel/install
@@ -47,6 +47,9 @@ define Package/capos-webpanel/install
 
 	$(INSTALL_DIR) $(1)$(CAP_WWW_DIR)
 	$(CP) -a ./htdocs/* $(1)$(CAP_WWW_DIR)/
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/90-capos-webpanel-uhttpd $(1)/etc/uci-defaults/90-capos-webpanel-uhttpd
 endef
 
 $(eval $(call BuildPackage,capos-webpanel))

--- a/package/capos/capos-webpanel/files/90-capos-webpanel-uhttpd
+++ b/package/capos/capos-webpanel/files/90-capos-webpanel-uhttpd
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# ArgosFS currently rejects fsync for px5g output under /etc on first boot.
+# Generate uhttpd's self-signed certificate on tmpfs instead.
+uci -q set uhttpd.main.cert='/tmp/uhttpd.crt'
+uci -q set uhttpd.main.key='/tmp/uhttpd.key'
+uci -q set uhttpd.defaults.key_type='rsa'
+uci -q commit uhttpd
+
+rm -f /etc/uhttpd.crt /etc/uhttpd.key /tmp/uhttpd.crt /tmp/uhttpd.key
+exit 0

--- a/package/capos/capos-webpanel/htdocs/assets/app.js
+++ b/package/capos/capos-webpanel/htdocs/assets/app.js
@@ -82,6 +82,7 @@ function resetSessionUi(message) {
   nodes.controlDrawer.classList.remove("open");
   nodes.loginView.style.display = "grid";
   nodes.appShell.classList.remove("ready");
+  nodes.desktopFrame.src = "about:blank";
   nodes.installBtn.disabled = true;
   nodes.inspectionBox.innerHTML = "<p>等待上传 CPK。</p>";
   if (message) {
@@ -297,6 +298,12 @@ function updateViewportOffsets() {
 }
 
 function refreshDesktopFrame() {
+  const appName = state.desktop?.app;
+  const item = state.apps.find((candidate) => candidate.app?.name === appName);
+  if (!appName || !item?.runtime?.running || !item.desktop?.port) {
+    nodes.desktopFrame.src = "about:blank";
+    return;
+  }
   nodes.desktopFrame.src = `/cgi-bin/cap/app?ts=${Date.now()}`;
 }
 

--- a/package/capos/capos-webpanel/htdocs/index.html
+++ b/package/capos/capos-webpanel/htdocs/index.html
@@ -45,7 +45,7 @@
 
         <main class="desktop">
           <div class="desktop-status" id="desktopStatus"></div>
-          <iframe class="desktop-frame" id="desktopFrame" src="/cgi-bin/cap/app" title="CapOS desktop app"></iframe>
+          <iframe class="desktop-frame" id="desktopFrame" src="about:blank" title="CapOS desktop app"></iframe>
         </main>
 
         <aside class="control-drawer" id="controlDrawer">

--- a/package/capos/capos-webpanel/src/app.cpp
+++ b/package/capos/capos-webpanel/src/app.cpp
@@ -1,6 +1,11 @@
 #include "common.hpp"
 
 #include <netdb.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/x509v3.h>
+#include <poll.h>
+#include <signal.h>
 #include <sys/socket.h>
 
 using namespace capos;
@@ -14,6 +19,57 @@ struct UpstreamResponse {
     std::string reason = "Bad Gateway";
     std::vector<std::pair<std::string, std::string>> headers;
     std::string body;
+};
+
+struct UpstreamConnection {
+    int fd = -1;
+    SSL_CTX* ctx = nullptr;
+    SSL* ssl = nullptr;
+    bool tls = false;
+
+    UpstreamConnection() = default;
+    UpstreamConnection(const UpstreamConnection&) = delete;
+    UpstreamConnection& operator=(const UpstreamConnection&) = delete;
+
+    UpstreamConnection(UpstreamConnection&& other) noexcept {
+        *this = std::move(other);
+    }
+
+    UpstreamConnection& operator=(UpstreamConnection&& other) noexcept {
+        if (this != &other) {
+            close();
+            fd = other.fd;
+            ctx = other.ctx;
+            ssl = other.ssl;
+            tls = other.tls;
+            other.fd = -1;
+            other.ctx = nullptr;
+            other.ssl = nullptr;
+            other.tls = false;
+        }
+        return *this;
+    }
+
+    ~UpstreamConnection() {
+        close();
+    }
+
+    void close() {
+        if (ssl != nullptr) {
+            SSL_shutdown(ssl);
+            SSL_free(ssl);
+            ssl = nullptr;
+        }
+        if (fd >= 0) {
+            ::close(fd);
+            fd = -1;
+        }
+        if (ctx != nullptr) {
+            SSL_CTX_free(ctx);
+            ctx = nullptr;
+        }
+        tls = false;
+    }
 };
 
 std::string effectivePathInfo() {
@@ -319,7 +375,7 @@ std::optional<std::string> decodeChunkedBody(const std::string& input) {
     return std::nullopt;
 }
 
-std::optional<UpstreamResponse> fetchHttp(const std::string& host, int port, const std::string& requestText) {
+std::optional<int> connectTcp(const std::string& host, int port) {
     addrinfo hints{};
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
@@ -347,44 +403,127 @@ std::optional<UpstreamResponse> fetchHttp(const std::string& host, int port, con
         return std::nullopt;
     }
 
-    ssize_t sentTotal = 0;
-    while (sentTotal < static_cast<ssize_t>(requestText.size())) {
-        const auto sent = send(sock, requestText.data() + sentTotal, requestText.size() - sentTotal, 0);
-        if (sent <= 0) {
-            close(sock);
-            return std::nullopt;
-        }
-        sentTotal += sent;
-    }
+    return sock;
+}
 
-    std::string raw;
-    std::array<char, 8192> buffer{};
-    while (true) {
-        const auto got = recv(sock, buffer.data(), buffer.size(), 0);
-        if (got <= 0) {
-            break;
-        }
-        raw.append(buffer.data(), static_cast<size_t>(got));
-    }
-    close(sock);
-
-    const auto sep = raw.find("\r\n\r\n");
-    const auto altSep = raw.find("\n\n");
-    size_t headerEnd = std::string::npos;
-    size_t headerSize = 0;
-    if (sep != std::string::npos) {
-        headerEnd = sep;
-        headerSize = 4;
-    } else if (altSep != std::string::npos) {
-        headerEnd = altSep;
-        headerSize = 2;
-    } else {
+std::optional<UpstreamConnection> openUpstream(const std::string& host, int port, const std::string& scheme, bool verifyTls) {
+    auto sock = connectTcp(host, port);
+    if (!sock.has_value()) {
         return std::nullopt;
     }
 
+    UpstreamConnection connection;
+    connection.fd = *sock;
+
+    if (scheme == "https") {
+        SSL_library_init();
+        SSL_load_error_strings();
+        connection.tls = true;
+        connection.ctx = SSL_CTX_new(TLS_client_method());
+        if (connection.ctx == nullptr) {
+            return std::nullopt;
+        }
+        if (verifyTls) {
+            SSL_CTX_set_verify(connection.ctx, SSL_VERIFY_PEER, nullptr);
+            SSL_CTX_set_default_verify_paths(connection.ctx);
+        } else {
+            SSL_CTX_set_verify(connection.ctx, SSL_VERIFY_NONE, nullptr);
+        }
+
+        connection.ssl = SSL_new(connection.ctx);
+        if (connection.ssl == nullptr) {
+            return std::nullopt;
+        }
+        SSL_set_fd(connection.ssl, connection.fd);
+        SSL_set_tlsext_host_name(connection.ssl, host.c_str());
+        if (verifyTls) {
+            X509_VERIFY_PARAM* param = SSL_get0_param(connection.ssl);
+            X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+            X509_VERIFY_PARAM_set1_host(param, host.c_str(), 0);
+        }
+        if (SSL_connect(connection.ssl) != 1) {
+            return std::nullopt;
+        }
+    }
+
+    return connection;
+}
+
+bool writeUpstream(UpstreamConnection& connection, const char* data, size_t size) {
+    size_t sentTotal = 0;
+    while (sentTotal < size) {
+        int sent = 0;
+        if (connection.tls) {
+            sent = SSL_write(connection.ssl, data + sentTotal, static_cast<int>(size - sentTotal));
+            if (sent <= 0) {
+                const auto err = SSL_get_error(connection.ssl, sent);
+                if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+                    continue;
+                }
+                return false;
+            }
+        } else {
+            const auto rawSent = send(connection.fd, data + sentTotal, size - sentTotal, 0);
+            if (rawSent <= 0) {
+                return false;
+            }
+            sent = static_cast<int>(rawSent);
+        }
+        sentTotal += static_cast<size_t>(sent);
+    }
+    return true;
+}
+
+bool writeUpstream(UpstreamConnection& connection, const std::string& data) {
+    return writeUpstream(connection, data.data(), data.size());
+}
+
+ssize_t readUpstream(UpstreamConnection& connection, char* buffer, size_t size) {
+    if (connection.tls) {
+        const auto got = SSL_read(connection.ssl, buffer, static_cast<int>(size));
+        if (got <= 0) {
+            const auto err = SSL_get_error(connection.ssl, got);
+            if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+                return -2;
+            }
+            return 0;
+        }
+        return got;
+    }
+    return recv(connection.fd, buffer, size, 0);
+}
+
+struct HeaderReadResult {
     UpstreamResponse response;
+    std::string firstBodyBytes;
+};
+
+std::optional<HeaderReadResult> readResponseHeaders(UpstreamConnection& connection) {
+    std::string raw;
+    std::array<char, 8192> buffer{};
+    size_t headerEnd = std::string::npos;
+    size_t headerSize = 0;
+
+    while (headerEnd == std::string::npos) {
+        const auto got = readUpstream(connection, buffer.data(), buffer.size());
+        if (got <= 0) {
+            return std::nullopt;
+        }
+        raw.append(buffer.data(), static_cast<size_t>(got));
+        const auto sep = raw.find("\r\n\r\n");
+        const auto altSep = raw.find("\n\n");
+        if (sep != std::string::npos) {
+            headerEnd = sep;
+            headerSize = 4;
+        } else if (altSep != std::string::npos) {
+            headerEnd = altSep;
+            headerSize = 2;
+        }
+    }
+
+    HeaderReadResult parsed;
     std::string headerBlock = raw.substr(0, headerEnd);
-    response.body = raw.substr(headerEnd + headerSize);
+    parsed.firstBodyBytes = raw.substr(headerEnd + headerSize);
 
     std::stringstream headers(headerBlock);
     std::string line;
@@ -395,10 +534,10 @@ std::optional<UpstreamResponse> fetchHttp(const std::string& host, int port, con
     {
         std::smatch match;
         if (std::regex_search(line, match, std::regex(R"(HTTP/\d+\.\d+\s+(\d+)\s*(.*))"))) {
-            response.status = std::stoi(match[1].str());
-            response.reason = trim(match[2].str());
-            if (response.reason.empty()) {
-                response.reason = reasonPhrase(response.status);
+            parsed.response.status = std::stoi(match[1].str());
+            parsed.response.reason = trim(match[2].str());
+            if (parsed.response.reason.empty()) {
+                parsed.response.reason = reasonPhrase(parsed.response.status);
             }
         }
     }
@@ -412,21 +551,54 @@ std::optional<UpstreamResponse> fetchHttp(const std::string& host, int port, con
         if (pos == std::string::npos) {
             continue;
         }
-        response.headers.emplace_back(trim(line.substr(0, pos)), trim(line.substr(pos + 1)));
+        parsed.response.headers.emplace_back(trim(line.substr(0, pos)), trim(line.substr(pos + 1)));
     }
+    return parsed;
+}
+
+std::optional<UpstreamResponse> fetchHttp(const std::string& host, int port, const std::string& scheme, bool verifyTls,
+                                          const std::string& requestText) {
+    auto connection = openUpstream(host, port, scheme, verifyTls);
+    if (!connection.has_value()) {
+        return std::nullopt;
+    }
+    if (!writeUpstream(*connection, requestText)) {
+        return std::nullopt;
+    }
+
+    auto parsed = readResponseHeaders(*connection);
+    if (!parsed.has_value()) {
+        return std::nullopt;
+    }
+    auto response = parsed->response;
+    response.body = parsed->firstBodyBytes;
+
+    std::array<char, 8192> buffer{};
+    while (true) {
+        const auto got = readUpstream(*connection, buffer.data(), buffer.size());
+        if (got <= 0) {
+            break;
+        }
+        response.body.append(buffer.data(), static_cast<size_t>(got));
+    }
+
     return response;
 }
 
 bool isHopByHop(const std::string& header);
 
 std::string buildForwardRequest(const std::string& host, int port, const std::string& upstreamPath, const std::string& body,
-                                const std::string& panelSessionId) {
+                                const std::string& panelSessionId, bool websocket = false) {
     std::ostringstream request;
     const auto method = getenvOrEmpty("REQUEST_METHOD").empty() ? "GET" : getenvOrEmpty("REQUEST_METHOD");
     request << method << ' ' << upstreamPath << " HTTP/1.1\r\n";
     request << "Host: " << host << ':' << port << "\r\n";
-    request << "Connection: close\r\n";
-    request << "Accept-Encoding: identity\r\n";
+    request << "Connection: " << (websocket ? "Upgrade" : "close") << "\r\n";
+    if (websocket) {
+        request << "Upgrade: websocket\r\n";
+    } else {
+        request << "Accept-Encoding: identity\r\n";
+    }
     request << "X-Forwarded-Host: " << hostWithoutPort() << "\r\n";
     request << "X-Forwarded-Proto: " << requestScheme() << "\r\n";
     request << "X-Forwarded-Prefix: " << proxyPrefix() << "\r\n";
@@ -462,10 +634,13 @@ std::string buildForwardRequest(const std::string& host, int port, const std::st
     if (!contentType.empty()) {
         request << "Content-Type: " << contentType << "\r\n";
     }
-    if (!body.empty()) {
+    if (!body.empty() && !websocket) {
         request << "Content-Length: " << body.size() << "\r\n";
     }
-    request << "\r\n" << body;
+    request << "\r\n";
+    if (!websocket) {
+        request << body;
+    }
     return request.str();
 }
 
@@ -483,7 +658,8 @@ bool isHopByHop(const std::string& header) {
            lowered == "content-length";
 }
 
-std::string rewriteResponseLocation(const std::string& value, const std::string& upstreamHost, int upstreamPort) {
+std::string rewriteResponseLocation(const std::string& value, const std::string& upstreamScheme,
+                                    const std::string& upstreamHost, int upstreamPort) {
     if (value.empty()) {
         return value;
     }
@@ -491,13 +667,13 @@ std::string rewriteResponseLocation(const std::string& value, const std::string&
         return proxyPrefix() + value;
     }
 
-    const auto httpPrefix = "http://" + upstreamHost + ":" + std::to_string(upstreamPort);
-    if (value.rfind(httpPrefix + "/", 0) == 0) {
-        return proxyPrefix() + value.substr(httpPrefix.size());
+    const auto prefixWithPort = upstreamScheme + "://" + upstreamHost + ":" + std::to_string(upstreamPort);
+    if (value.rfind(prefixWithPort + "/", 0) == 0) {
+        return proxyPrefix() + value.substr(prefixWithPort.size());
     }
-    const auto httpPrefixNoPort = "http://" + upstreamHost;
-    if (value.rfind(httpPrefixNoPort + "/", 0) == 0) {
-        return proxyPrefix() + value.substr(httpPrefixNoPort.size());
+    const auto prefixNoPort = upstreamScheme + "://" + upstreamHost;
+    if (value.rfind(prefixNoPort + "/", 0) == 0) {
+        return proxyPrefix() + value.substr(prefixNoPort.size());
     }
     return value;
 }
@@ -532,6 +708,141 @@ std::string rewriteSetCookiePath(const std::string& value) {
         out << parts[i];
     }
     return out.str();
+}
+
+bool writeStdoutAll(const char* data, size_t size) {
+    size_t writtenTotal = 0;
+    while (writtenTotal < size) {
+        const auto written = ::write(STDOUT_FILENO, data + writtenTotal, size - writtenTotal);
+        if (written <= 0) {
+            return false;
+        }
+        writtenTotal += static_cast<size_t>(written);
+    }
+    return true;
+}
+
+bool writeStdoutAll(const std::string& data) {
+    return writeStdoutAll(data.data(), data.size());
+}
+
+void writeWebSocketSwitchingHeaders(const UpstreamResponse& response) {
+    bool hasUpgrade = false;
+    bool hasConnection = false;
+    std::cout << "Status: 101 Switching Protocols\r\n";
+    for (const auto& [name, value] : response.headers) {
+        const auto lowered = lowerAscii(name);
+        if (lowered == "content-length" || lowered == "transfer-encoding" || lowered == "content-type") {
+            continue;
+        }
+        if (lowered == "upgrade") {
+            hasUpgrade = true;
+        }
+        if (lowered == "connection") {
+            hasConnection = true;
+        }
+        std::cout << name << ": " << value << "\r\n";
+    }
+    if (!hasUpgrade) {
+        std::cout << "Upgrade: websocket\r\n";
+    }
+    if (!hasConnection) {
+        std::cout << "Connection: Upgrade\r\n";
+    }
+    std::cout << "\r\n";
+    std::cout.flush();
+}
+
+void relayWebSocket(UpstreamConnection& connection, const std::string& initialBytes) {
+    if (!initialBytes.empty()) {
+        writeStdoutAll(initialBytes);
+    }
+
+    bool clientOpen = true;
+    std::array<char, 8192> buffer{};
+    while (true) {
+        bool upstreamReady = connection.tls && SSL_pending(connection.ssl) > 0;
+        pollfd fds[2]{};
+        nfds_t nfds = 0;
+        if (clientOpen) {
+            fds[nfds].fd = STDIN_FILENO;
+            fds[nfds].events = POLLIN;
+            ++nfds;
+        }
+        fds[nfds].fd = connection.fd;
+        fds[nfds].events = POLLIN;
+        ++nfds;
+
+        if (!upstreamReady) {
+            const auto ready = poll(fds, nfds, -1);
+            if (ready < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                break;
+            }
+        }
+
+        size_t index = 0;
+        if (clientOpen) {
+            if ((fds[index].revents & (POLLIN | POLLHUP | POLLERR)) != 0) {
+                const auto got = ::read(STDIN_FILENO, buffer.data(), buffer.size());
+                if (got > 0) {
+                    if (!writeUpstream(connection, buffer.data(), static_cast<size_t>(got))) {
+                        break;
+                    }
+                } else {
+                    clientOpen = false;
+                }
+            }
+            ++index;
+        }
+
+        if (upstreamReady || (fds[index].revents & (POLLIN | POLLHUP | POLLERR)) != 0) {
+            const auto got = readUpstream(connection, buffer.data(), buffer.size());
+            if (got == -2) {
+                continue;
+            }
+            if (got <= 0) {
+                break;
+            }
+            if (!writeStdoutAll(buffer.data(), static_cast<size_t>(got))) {
+                break;
+            }
+        }
+    }
+}
+
+std::string renderStatusPage(const std::string& selectedApp, const std::string& infoJson, const std::string& message);
+
+bool proxyWebSocket(const Session& session, const std::string& selectedApp, const std::string& infoJson,
+                    const std::string& host, int port, const std::string& scheme, bool verifyTls,
+                    const std::string& upstreamPath) {
+    auto connection = openUpstream(host, port, scheme, verifyTls);
+    if (!connection.has_value()) {
+        sendHtml(502, renderStatusPage(selectedApp, infoJson, "WebSocket 连接上游失败，目标服务可能尚未监听。"));
+        return false;
+    }
+
+    const auto requestText = buildForwardRequest(host, port, upstreamPath, "", session.id, true);
+    if (!writeUpstream(*connection, requestText)) {
+        sendHtml(502, renderStatusPage(selectedApp, infoJson, "WebSocket 握手请求发送失败。"));
+        return false;
+    }
+
+    auto parsed = readResponseHeaders(*connection);
+    if (!parsed.has_value()) {
+        sendHtml(502, renderStatusPage(selectedApp, infoJson, "WebSocket 上游没有返回有效握手响应。"));
+        return false;
+    }
+    if (parsed->response.status != 101) {
+        sendHtml(502, renderStatusPage(selectedApp, infoJson, "WebSocket 上游拒绝升级连接，未返回 101 Switching Protocols。"));
+        return false;
+    }
+
+    writeWebSocketSwitchingHeaders(parsed->response);
+    relayWebSocket(*connection, parsed->firstBodyBytes);
+    return true;
 }
 
 std::string renderStatusPage(const std::string& selectedApp, const std::string& infoJson, const std::string& message) {
@@ -574,14 +885,11 @@ std::string renderStatusPage(const std::string& selectedApp, const std::string& 
 }  // namespace
 
 int main() {
+    signal(SIGPIPE, SIG_IGN);
+
     const auto session = currentSession();
     if (!session.has_value()) {
         sendHtml(401, renderEmpty("需要登录", "请先返回 CapOS 面板完成登录，然后再查看桌面应用。"));
-        return 0;
-    }
-
-    if (isWebSocketRequest()) {
-        sendHtml(501, renderEmpty("暂不支持 WebSocket", "当前桌面代理这一轮只支持 HTTP 请求。WebSocket 转发会在后续版本补齐，当前不会静默失败。"));
         return 0;
     }
 
@@ -618,15 +926,16 @@ int main() {
     const auto scheme = findJsonString(info.output, "scheme").value_or("http");
     const auto host = findJsonString(info.output, "target_host");
     const auto port = findJsonInt(info.output, "port");
+    const auto httpsSkipCheck = findJsonBool(info.output, "https_skip_check").value_or(true);
 
-    if (!running || !host.has_value() || !port.has_value() || scheme != "http") {
-        std::string why = "当前桌面应用还没有可代理的 HTTP 入口。";
+    if (!running || !host.has_value() || !port.has_value() || (scheme != "http" && scheme != "https")) {
+        std::string why = "当前桌面应用还没有可代理的 HTTP/HTTPS 入口。";
         if (!running) {
             why = "当前桌面应用还没有启动。";
         } else if (!port.has_value()) {
             why = "当前桌面应用在元数据里没有声明 service 端口。";
-        } else if (scheme != "http") {
-            why = "当前桌面应用仅声明了 HTTPS 入口，这一轮代理先优先支持 HTTP。";
+        } else if (scheme != "http" && scheme != "https") {
+            why = "当前桌面应用声明了暂不支持的 service scheme。";
         }
         sendHtml(200, renderStatusPage(selectedApp, info.output, why));
         return 0;
@@ -644,9 +953,14 @@ int main() {
         upstreamPath += upstreamQuery;
     }
 
+    if (isWebSocketRequest()) {
+        proxyWebSocket(*session, selectedApp, info.output, *host, static_cast<int>(*port), scheme, !httpsSkipCheck, upstreamPath);
+        return 0;
+    }
+
     const auto requestBody = readRequestBody();
     const auto requestText = buildForwardRequest(*host, static_cast<int>(*port), upstreamPath, requestBody, session->id);
-    auto response = fetchHttp(*host, static_cast<int>(*port), requestText);
+    auto response = fetchHttp(*host, static_cast<int>(*port), scheme, !httpsSkipCheck, requestText);
     if (!response.has_value()) {
         sendHtml(502, renderStatusPage(selectedApp, info.output, "连接桌面应用失败，可能容器尚未完全启动，或目标服务没有监听声明的端口。"));
         return 0;
@@ -689,7 +1003,7 @@ int main() {
             continue;
         }
         if (lowered == "location") {
-            outHeaders.emplace_back(name, rewriteResponseLocation(value, *host, static_cast<int>(*port)));
+            outHeaders.emplace_back(name, rewriteResponseLocation(value, scheme, *host, static_cast<int>(*port)));
         } else if (lowered == "set-cookie") {
             outHeaders.emplace_back(name, rewriteSetCookiePath(value));
         } else {

--- a/tests/webpanel_proxy_smoke.sh
+++ b/tests/webpanel_proxy_smoke.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_BIN="${APP_BIN:-/tmp/capos-app-smoke}"
+TMPDIR="$(mktemp -d)"
+SESSION_ID="0123456789abcdef0123456789abcdef0123456789abcdef"
+SESSION_DIR="/tmp/capos-webpanel/sessions"
+SESSION_PATH="$SESSION_DIR/$SESSION_ID.session"
+HTTPS_PID=""
+WS_PID=""
+
+cleanup() {
+    [[ -n "$HTTPS_PID" ]] && kill "$HTTPS_PID" 2>/dev/null || true
+    [[ -n "$WS_PID" ]] && kill "$WS_PID" 2>/dev/null || true
+    rm -f "$SESSION_PATH"
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+if [[ ! -x "$APP_BIN" ]]; then
+    g++ -std=gnu++17 -I"$ROOT_DIR/package/capos/capos-webpanel/src" \
+        -o "$APP_BIN" "$ROOT_DIR/package/capos/capos-webpanel/src/app.cpp" \
+        -lcrypt -lssl -lcrypto
+fi
+
+mkdir -p "$SESSION_DIR" "$TMPDIR/bin"
+cat >"$SESSION_PATH" <<SESSION
+id=$SESSION_ID
+username=testuser
+uid=1000
+is_sudo=1
+created_at=1700000000
+expires_at=4102444800
+SESSION
+
+cat >"$TMPDIR/bin/capbox" <<'CAPBOX'
+#!/usr/bin/env sh
+if [ "$1 $2" = "desktop get" ]; then
+  printf '{"ok":true,"app":"demo"}\n'
+  exit 0
+fi
+if [ "$1 $2 $3" = "app info demo" ]; then
+  cat "$CAPBOX_INFO_JSON"
+  exit 0
+fi
+echo "unexpected capbox call: $*" >&2
+exit 1
+CAPBOX
+chmod +x "$TMPDIR/bin/capbox"
+
+wait_for_port_file() {
+    local path="$1"
+    for _ in $(seq 1 50); do
+        [[ -s "$path" ]] && return 0
+        sleep 0.1
+    done
+    echo "timed out waiting for $path" >&2
+    exit 1
+}
+
+openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout "$TMPDIR/key.pem" \
+    -out "$TMPDIR/cert.pem" \
+    -subj "/CN=127.0.0.1" \
+    -days 1 >/dev/null 2>&1
+
+python3 - "$TMPDIR/https.port" "$TMPDIR/cert.pem" "$TMPDIR/key.pem" <<'PY' &
+import socket
+import ssl
+import sys
+
+port_file, cert_file, key_file = sys.argv[1:4]
+server = socket.socket()
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", 0))
+server.listen(1)
+with open(port_file, "w", encoding="utf-8") as handle:
+    handle.write(str(server.getsockname()[1]))
+context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+context.load_cert_chain(cert_file, key_file)
+conn, _ = server.accept()
+with context.wrap_socket(conn, server_side=True) as tls:
+    data = b""
+    while b"\r\n\r\n" not in data:
+        chunk = tls.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    body = b'<html><head></head><body><a href="/next">next</a></body></html>'
+    tls.sendall(
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Type: text/html; charset=utf-8\r\n"
+        b"Set-Cookie: upstream=1; Path=/\r\n"
+        b"Location: /next\r\n"
+        + b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+        b"\r\n" + body
+    )
+server.close()
+PY
+HTTPS_PID=$!
+wait_for_port_file "$TMPDIR/https.port"
+HTTPS_PORT="$(cat "$TMPDIR/https.port")"
+
+cat >"$TMPDIR/info-https.json" <<JSON
+{
+  "ok": true,
+  "app": {"name": "demo", "version": "1.0", "nickname": "Demo"},
+  "runtime": {"running": true, "container_name": "capbox_u_1000_demo", "ip": "127.0.0.1"},
+  "desktop": {"scheme": "https", "port": $HTTPS_PORT, "target_host": "127.0.0.1", "https_skip_check": true},
+  "permissions": {"host_network": false, "host_exec": false},
+  "portmaps": []
+}
+JSON
+
+https_output="$(
+  env -i \
+    PATH="$TMPDIR/bin:$PATH" \
+    CAPBOX_INFO_JSON="$TMPDIR/info-https.json" \
+    REQUEST_METHOD=GET \
+    PATH_INFO=/ \
+    QUERY_STRING= \
+    HTTP_COOKIE="capos_session=$SESSION_ID" \
+    "$APP_BIN" < /dev/null
+)"
+
+grep -q "Status: 200 OK" <<<"$https_output"
+grep -q "Set-Cookie: upstream=1; Path=/cgi-bin/cap/app" <<<"$https_output"
+grep -q "Location: /cgi-bin/cap/app/next" <<<"$https_output"
+grep -q 'href="/cgi-bin/cap/app/next"' <<<"$https_output"
+
+python3 - "$TMPDIR/ws.port" <<'PY' &
+import socket
+import sys
+import time
+
+port_file = sys.argv[1]
+server = socket.socket()
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind(("127.0.0.1", 0))
+server.listen(1)
+with open(port_file, "w", encoding="utf-8") as handle:
+    handle.write(str(server.getsockname()[1]))
+conn, _ = server.accept()
+with conn:
+    data = b""
+    while b"\r\n\r\n" not in data:
+        chunk = conn.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    conn.sendall(
+        b"HTTP/1.1 101 Switching Protocols\r\n"
+        b"Upgrade: websocket\r\n"
+        b"Connection: Upgrade\r\n"
+        b"Sec-WebSocket-Accept: smoke\r\n"
+        b"\r\n"
+        b"\x81\x02ok"
+    )
+    time.sleep(0.1)
+server.close()
+PY
+WS_PID=$!
+wait_for_port_file "$TMPDIR/ws.port"
+WS_PORT="$(cat "$TMPDIR/ws.port")"
+
+cat >"$TMPDIR/info-ws.json" <<JSON
+{
+  "ok": true,
+  "app": {"name": "demo", "version": "1.0", "nickname": "Demo"},
+  "runtime": {"running": true, "container_name": "capbox_u_1000_demo", "ip": "127.0.0.1"},
+  "desktop": {"scheme": "http", "port": $WS_PORT, "target_host": "127.0.0.1", "https_skip_check": false},
+  "permissions": {"host_network": false, "host_exec": false},
+  "portmaps": []
+}
+JSON
+
+ws_output="$(
+  env -i \
+    PATH="$TMPDIR/bin:$PATH" \
+    CAPBOX_INFO_JSON="$TMPDIR/info-ws.json" \
+    REQUEST_METHOD=GET \
+    PATH_INFO=/socket \
+    QUERY_STRING= \
+    HTTP_COOKIE="capos_session=$SESSION_ID" \
+    HTTP_UPGRADE=websocket \
+    HTTP_CONNECTION=Upgrade \
+    HTTP_SEC_WEBSOCKET_KEY=smoke \
+    HTTP_SEC_WEBSOCKET_VERSION=13 \
+    "$APP_BIN" < /dev/null
+)"
+
+grep -q "Status: 101 Switching Protocols" <<<"$ws_output"
+grep -q "Sec-WebSocket-Accept: smoke" <<<"$ws_output"
+grep -q "ok" <<<"$ws_output"
+
+echo "webpanel proxy smoke passed"


### PR DESCRIPTION
## Summary
- switch capbox/Podman first-boot networking to netavark nftables and fix portmap forwarding to container IPs
- support HTTPS upstream desktop services and WebSocket upgrade relays in the app proxy
- keep the desktop iframe blank until a running desktop service exists, avoiding stale login/proxy states
- generate uhttpd TLS cert/key under `/tmp` for ArgosFS first boot and ensure ArgosFS roots include `/run`
- add CI smoke coverage for HTTPS proxy rewriting and WebSocket 101 responses

## QEMU validation
Booted `capos-x86-64-generic-argosfs-combined.vmdk` under QEMU with HTTP/HTTPS forwards:
- logged into `https://127.0.0.1:4558/cap/`
- uploaded and installed `/root/project/capp-helloworld/bin/helloworld_v0.2.0_amd64.cpk`
- verified app list, CPK review, install confirmation, running state, and desktop iframe rendering
- verified `/cgi-bin/cap/app` proxy response over HTTP/HTTPS
- verified port mapping add/remove and VM-local `127.0.0.1:18080 -> 10.89.0.2:80` forwarding

Local screenshots are under `output/playwright/` and intentionally not committed.

## Tests
- `bash -n package/capos/capbox/files/capbox`
- `sh -n package/capos/capbox/files/91-capbox-podman-network`
- `sh -n package/capos/capos-webpanel/files/90-capos-webpanel-uhttpd`
- `g++ -std=gnu++17 -Ipackage/capos/capos-webpanel/src -o /tmp/capos-api-smoke package/capos/capos-webpanel/src/api.cpp -lcrypt`
- `g++ -std=gnu++17 -Ipackage/capos/capos-webpanel/src -o /tmp/capos-app-smoke package/capos/capos-webpanel/src/app.cpp -lcrypt -lssl -lcrypto`
- `tests/capbox_logic_tests.sh`
- `tests/webpanel_frontend_smoke.sh`
- `tests/webpanel_proxy_smoke.sh`
- `make defconfig`
- `make -j$(nproc) prepare-tmpinfo V=s`
- `make -j$(nproc) package/capos/capbox/compile package/capos/capos-webpanel/compile`
- `make -j1 package/install`
- `make -j1 target/linux/install V=s`
