### PR TITLE
Raise ArgosFS rootfs size to 512 MiB

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -360,13 +360,13 @@ menu "Target Images"
 		int "Root filesystem partition size (in MiB)"
 		depends on USES_ROOTFS_PART || TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_ARGOSFS
 		default 448 if TARGET_mediatek || TARGET_microchipsw
-		default 384 if TARGET_ROOTFS_ARGOSFS
+		default 512 if TARGET_ROOTFS_ARGOSFS
 		default 256 if PACKAGE_podman
 		default 232 if TARGET_loongarch64
 		default 104
 		help
 		  Select the root filesystem partition size.
-		  When ArgosFS is enabled, the default is raised to 384 MiB to
+		  When ArgosFS is enabled, the default is raised to 512 MiB to
 		  leave room for raw metadata, journal, and normal rootfs growth.
 		  When Podman is enabled, the default is raised to 256 MiB to
 		  accommodate the larger root filesystem footprint.

--- a/include/image.mk
+++ b/include/image.mk
@@ -225,8 +225,8 @@ ifneq ($(CONFIG_TARGET_ROOTFS_ARGOSFS),)
   ifneq ($(shell [ -n "$(CONFIG_TARGET_KERNEL_PARTSIZE)" ] && [ "$(CONFIG_TARGET_KERNEL_PARTSIZE)" -lt 64 ] && echo y),)
     $(error TARGET_KERNEL_PARTSIZE=$(CONFIG_TARGET_KERNEL_PARTSIZE) MiB is too small for ArgosFS initramfs kernel. Set it to at least 64 MiB or regenerate the config with the updated defaults)
   endif
-  ifneq ($(shell [ -n "$(CONFIG_TARGET_ROOTFS_PARTSIZE)" ] && [ "$(CONFIG_TARGET_ROOTFS_PARTSIZE)" -lt 384 ] && echo y),)
-    $(error TARGET_ROOTFS_PARTSIZE=$(CONFIG_TARGET_ROOTFS_PARTSIZE) MiB is too small for ArgosFS. Set it to at least 384 MiB or regenerate the config with the updated defaults)
+  ifneq ($(shell [ -n "$(CONFIG_TARGET_ROOTFS_PARTSIZE)" ] && [ "$(CONFIG_TARGET_ROOTFS_PARTSIZE)" -lt 512 ] && echo y),)
+    $(error TARGET_ROOTFS_PARTSIZE=$(CONFIG_TARGET_ROOTFS_PARTSIZE) MiB is too small for ArgosFS. Set it to at least 512 MiB or regenerate the config with the updated defaults)
   endif
 endif
 endif


### PR DESCRIPTION
Raise the ArgosFS root filesystem partition default and minimum build-time guard from 384 MiB to 512 MiB.\n\nThis gives CapOS ArgosFS images a cleaner baseline for metadata, journal, and normal rootfs growth.