### PR TITLE
Prefer ArgosFS rootfs size default

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -359,8 +359,8 @@ menu "Target Images"
 	config TARGET_ROOTFS_PARTSIZE
 		int "Root filesystem partition size (in MiB)"
 		depends on USES_ROOTFS_PART || TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_ARGOSFS
-		default 448 if TARGET_mediatek || TARGET_microchipsw
 		default 512 if TARGET_ROOTFS_ARGOSFS
+		default 448 if TARGET_mediatek || TARGET_microchipsw
 		default 256 if PACKAGE_podman
 		default 232 if TARGET_loongarch64
 		default 104


### PR DESCRIPTION
Move the ArgosFS 512 MiB rootfs partition default before board-specific 448 MiB defaults.\n\nKconfig uses the first matching default, so this prevents any future ArgosFS-enabled mediatek or microchipsw configuration from defaulting below the enforced 512 MiB minimum.