### PR TITLE
gpgme: pin gpgrt-config to target staging

### DIFF
--- a/feeds/packages/libs/gpgme/Makefile
+++ b/feeds/packages/libs/gpgme/Makefile
@@ -19,6 +19,8 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
+CONFIGURE_VARS += ac_cv_path_GPGRT_CONFIG="$(STAGING_DIR)/usr/bin/gpgrt-config"
+
 define Package/libgpgme
   SECTION:=libs
   CATEGORY:=Libraries


### PR DESCRIPTION
## Summary

- force `gpgme` configure to use `$(STAGING_DIR)/usr/bin/gpgrt-config`
- prevent GitHub runner `/usr/bin/gpgrt-config` from injecting glibc `/usr/include` into musl cross-compilation

## Failure fixed

The x86_64 and aarch64 image builds failed while compiling `gpgme-tool.c` because host glibc headers and target musl fortify headers were included together, causing duplicate definitions such as `recv`, `recvfrom`, `read`, and `strncpy`.

## Scope

One package recipe change, two added lines, no unrelated feed changes.