### PR TITLE
ci: make OS real boot triggers future-proof

### DIFF
--- a/.github/workflows/os-real-boot.yml
+++ b/.github/workflows/os-real-boot.yml
@@ -3,34 +3,48 @@ name: OS Real Boot Check
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - ".config"
-      - ".github/workflows/os-real-boot.yml"
-      - "config/**"
-      - "feeds.conf*"
-      - "include/**"
-      - "package/capos/**"
-      - "package/utils/argosfs/**"
-      - "scripts/ci/**"
-      - "target/linux/generic/**"
-      - "target/linux/x86/**"
-      - "target/linux/armsr/**"
-      - "toolchain/**"
+    # Default to running for repository changes so new build inputs and
+    # vendored feeds cannot silently bypass the real image build. Ignore only
+    # files that cannot affect the produced CapOS images.
+    paths-ignore:
+      - ".devcontainer/**"
+      - ".github/FUNDING.yml"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/labeler.yml"
+      - ".github/pull_request_template"
+      - ".github/workflows/greetings.yml"
+      - ".github/workflows/issue-summary.yml"
+      - ".github/workflows/labeler.yml"
+      - ".github/workflows/os-sanity.yml"
+      - ".github/workflows/stale.yml"
+      - "CODE_OF_CONDUCT.md"
+      - "CONTRIBUTING.md"
+      - "README.md"
+      - "SECURITY.md"
+      - "TODO.md"
+      - "website/**"
   push:
     branches: ["main"]
-    paths:
-      - ".config"
-      - ".github/workflows/os-real-boot.yml"
-      - "config/**"
-      - "feeds.conf*"
-      - "include/**"
-      - "package/capos/**"
-      - "package/utils/argosfs/**"
-      - "scripts/ci/**"
-      - "target/linux/generic/**"
-      - "target/linux/x86/**"
-      - "target/linux/armsr/**"
-      - "toolchain/**"
+    # Default to running for repository changes so new build inputs and
+    # vendored feeds cannot silently bypass the real image build. Ignore only
+    # files that cannot affect the produced CapOS images.
+    paths-ignore:
+      - ".devcontainer/**"
+      - ".github/FUNDING.yml"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/labeler.yml"
+      - ".github/pull_request_template"
+      - ".github/workflows/greetings.yml"
+      - ".github/workflows/issue-summary.yml"
+      - ".github/workflows/labeler.yml"
+      - ".github/workflows/os-sanity.yml"
+      - ".github/workflows/stale.yml"
+      - "CODE_OF_CONDUCT.md"
+      - "CONTRIBUTING.md"
+      - "README.md"
+      - "SECURITY.md"
+      - "TODO.md"
+      - "website/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- replace the fragile build-path allowlist with a narrow non-build ignore list
- ensure vendored feeds, all packages, build scripts, tools, rootfs overlays, and future build inputs trigger real image builds
- keep documentation and repository-management-only changes from launching the six-hour build matrix

## Validation

- `actionlint .github/workflows/os-real-boot.yml`
- YAML syntax parse
- the workflow file itself remains triggerable on both pull requests and pushes