### PR TITLE
ci: extend arm64 real boot timeout

### DIFF
--- a/.github/workflows/os-real-boot.yml
+++ b/.github/workflows/os-real-boot.yml
@@ -70,9 +70,13 @@ jobs:
           - name: x86_64
             target: x86
             subtarget: "64"
+            boot_timeout_s: 360
           - name: aarch64
             target: armsr
             subtarget: armv8
+            # AArch64 runs entirely under TCG on GitHub-hosted x86 runners.
+            # ArgosFS root mount and userspace startup can exceed six minutes.
+            boot_timeout_s: 720
 
     steps:
       - name: Checkout
@@ -205,7 +209,7 @@ jobs:
         run: |
           set -euxo pipefail
           CAPOS_CI_ARTIFACT_DIR=ci-artifacts \
-          CAPOS_CI_BOOT_TIMEOUT_S=360 \
+          CAPOS_CI_BOOT_TIMEOUT_S=${{ matrix.boot_timeout_s }} \
             scripts/ci/qemu-port-check.sh "${{ matrix.target }}" "${{ matrix.subtarget }}"
 
       - name: Upload diagnostics


### PR DESCRIPTION
## Summary

- keep the x86_64 real-boot probe timeout at 360 seconds
- give the aarch64 TCG job 720 seconds for ArgosFS mount and userspace startup
- pass the timeout through the existing build matrix

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/os-real-boot.yml", aliases: true)'`
- `actionlint .github/workflows/os-real-boot.yml`
- `git diff --check`

## Context

Run 29345122811 reached a mounted ArgosFS root and completed aarch64 kernel-module loading, but the common 360-second deadline expired before `br-lan` and the webpanel became available. The x86_64 job completed successfully under the existing limit.